### PR TITLE
Bug/split

### DIFF
--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -222,12 +222,16 @@ c.xcmsSet <- function(...) {
 }
 
 split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
-  if (any(! f %in% xs@phenoData[,"class"])) {
-    stop("Non-existant class specified.")
+  if (length(f) < nrow(xs@phenoData)) {
+    warning("f is shorter than the number of samples, extra samples will be discarded.")
     }
+  if (length(f) > nrow(xs@phenoData)) {
+    warning("f is longer than the number of samples, extra factors will be ignored.")
+    f = f[1:nrow(xs@phenoData)]
+  }
 
-  split.samps = lapply(f, function(x) {
-    which(xs@phenoData[,"class"] %in% x)
+  split.samps = lapply(unique(f), function(x) {
+    which(f == x)
     })
   if (!drop) {
     split.samps[[length(split.samps) + 1]] = which(! xs@phenoData[,"class"] %in% f)
@@ -236,8 +240,6 @@ split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
   
   lcsets = lapply(split.samps, function(samps) {
     xs.n = new("xcmsSet")
-    
-
     
     peaks(xs.n) = xs@peaks[xs@peaks[,"sample"] %in% samps,,drop=F]
     xs.n@peaks[,"sample"] = rank(xs.n@peaks[,"sample"], ties.method="max")
@@ -251,7 +253,7 @@ split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
     xs.n@rt$corrected = xs@rt$corrected[samps]
     xs.n
     })
-  names(lcsets) = as.character(f)
+  names(lcsets) = as.character(unique(f))
   return(lcsets)  
 }
 

--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -225,12 +225,19 @@ split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
   if (any(! f %in% xs@phenoData[,"class"])) {
     stop("Non-existant class specified.")
     }
+
+  split.samps = lapply(f, function(x) {
+    which(xs@phenoData[,"class"] %in% x)
+    })
+  if (!drop) {
+    split.samps[[length(split.samps) + 1]] = which(! xs@phenoData[,"class"] %in% f)
+    f = c(f, "others")
+  }
   
-  
-  lcsets = lapply(f, function(x) {
+  lcsets = lapply(split.samps, function(samps) {
     xs.n = new("xcmsSet")
     
-    samps = which(xs@phenoData[,"class"] == x)
+
     
     peaks(xs.n) = xs@peaks[xs@peaks[,"sample"] %in% samps,,drop=F]
     xs.n@peaks[,"sample"] = rank(xs.n@peaks[,"sample"], ties.method="max")

--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -226,56 +226,26 @@ split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
     stop("Non-existant class specified.")
     }
   
-  samp.groups = lapply(f, function(x) {
-    xs@phenoData[,"class"] == x
-    })
   
   lcsets = lapply(f, function(x) {
     xs.n = new("xcmsSet")
     
+    samps = which(xs@phenoData[,"class"] == x)
     
+    peaks(xs.n) = xs@peaks[xs@peaks[,"sample"] %in% samps,,drop=F]
+    xs.n@peaks[,"sample"] = rank(xs.n@peaks[,"sample"], ties.method="max")
     
+    sampnames(xs.n) = rownames(xs@phenoData)[samps]
+    sampclass(xs.n) = factor(xs@phenoData[samps,"class"])
+    
+    xs.n@filepaths = xs@filepaths[samps]
+    profinfo(xs.n) = profinfo(xs)
+    xs.n@rt$raw = xs@rt$raw[samps]
+    xs.n@rt$corrected = xs@rt$corrected[samps]
+    xs.n
     })
-  names(lcsets) = levels(f)
-  return(lcsets)
-  
-    if (!is.factor(f))
-        f <- factor(f)
-    sampidx <- unclass(f)
-    peakmat <- peaks(x)
-    samples <- sampnames(x)
-    classlabel <- sampclass(x)
-    cdffiles <- filepaths(x)
-    prof <- profinfo(x)
-    rtraw <- x@rt$raw
-    rtcor <- x@rt$corrected
-
-    lcsets <- vector("list", length(levels(f)))
-    names(lcsets) <- levels(f)
-
-    for (i in unique(sampidx)) {
-        lcsets[[i]] <- new("xcmsSet")
-
-        samptrans <- numeric(length(f))
-        samptrans[sampidx == i] <- rank(which(sampidx == i))
-        samp <- samptrans[peakmat[,"sample"]]
-        sidx <- which(samp != 0)
-        cpeaks <- peakmat[sidx,, drop=FALSE]
-        cpeaks[,"sample"] <- samp[sidx]
-        peaks(lcsets[[i]]) <- cpeaks
-
-        sampnames(lcsets[[i]]) <- samples[sampidx == i]
-        sampclass(lcsets[[i]]) <- classlabel[sampidx == i, drop = TRUE]
-        filepaths(lcsets[[i]]) <- cdffiles[sampidx == i]
-        profinfo(lcsets[[i]]) <- prof
-        lcsets[[i]]@rt$raw <- rtraw[sampidx == i]
-        lcsets[[i]]@rt$corrected <- rtcor[sampidx == i]
-    }
-
-    if (drop)
-        lcsets <- lcsets[seq(along = lcsets) %in% sampidx]
-
-    lcsets
+  names(lcsets) = as.character(f)
+  return(lcsets)  
 }
 
 setMethod("peaks", c("xcmsSet","missing"), function(object) object@peaks)

--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -221,8 +221,24 @@ c.xcmsSet <- function(...) {
     invisible(object)
 }
 
-split.xcmsSet <- function(x, f, drop = TRUE, ...) {
-
+split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
+  if (any(! f %in% xs@phenoData[,"class"])) {
+    stop("Non-existant class specified.")
+    }
+  
+  samp.groups = lapply(f, function(x) {
+    xs@phenoData[,"class"] == x
+    })
+  
+  lcsets = lapply(f, function(x) {
+    xs.n = new("xcmsSet")
+    
+    
+    
+    })
+  names(lcsets) = levels(f)
+  return(lcsets)
+  
     if (!is.factor(f))
         f <- factor(f)
     sampidx <- unclass(f)

--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -225,20 +225,21 @@ split.xcmsSet <- function(xs, f, drop = TRUE, ...) {
   if (length(f) < nrow(xs@phenoData)) {
     warning("f is shorter than the number of samples, extra samples will be discarded.")
     }
-  if (length(f) > nrow(xs@phenoData)) {
-    warning("f is longer than the number of samples, extra factors will be ignored.")
+  if (length(f) > nrow(xs@phenoData) & drop) {
+    warning("f is longer than the number of samples, extra factors will be discarded.")
     f = f[1:nrow(xs@phenoData)]
+  }
+  if (length(f) > nrow(xs@phenoData) & !drop) {
+    warning("f is longer than the number of samples, extra factors will be NULL.")
   }
 
   split.samps = lapply(unique(f), function(x) {
-    which(f == x)
+    samps = which(f == x)
+    samps[samps <= nrow(xs@phenoData)]
     })
-  if (!drop) {
-    split.samps[[length(split.samps) + 1]] = which(! xs@phenoData[,"class"] %in% f)
-    f = c(f, "others")
-  }
-  
+
   lcsets = lapply(split.samps, function(samps) {
+    if(length(samps) < 1) {return(NULL)}
     xs.n = new("xcmsSet")
     
     peaks(xs.n) = xs@peaks[xs@peaks[,"sample"] %in% samps,,drop=F]

--- a/inst/unitTests/runit.splitCombine.R
+++ b/inst/unitTests/runit.splitCombine.R
@@ -30,3 +30,26 @@ testCombine <- function() {
     xsl <- split(faahko,sampclass(faahko))
     checkEqualsNumeric(length(sampnames(c(xsl[[1]], xsl[[2]]))), 12)
 }
+
+testSplitFactorShort = function() {
+  f = c("1", "2", "2")
+  xsl <- split(faahko, f)
+  for (x in unique(f)) {
+    num.samps = sum(x==f)
+    checkEqualsNumeric(length(xsl[[x]]@filepaths), num.samps)
+    checkEqualsNumeric(nrow(xsl[[x]]@phenoData), num.samps)
+    checkEqualsNumeric(length(xsl[[x]]@rt$raw), num.samps)
+  }
+}
+
+testSplitFactorLong = function() {
+  f = c(1,2, NULL, NULL, NULL, NULL, NULL,1,1,1,1,1,1,1,1,1)
+  f = c("1", "2", "2")
+  xsl <- split(faahko, f)
+  for (x in unique(f)) {
+    num.samps = sum(x==f)
+    checkEqualsNumeric(length(xsl[[x]]@filepaths), num.samps)
+    checkEqualsNumeric(nrow(xsl[[x]]@phenoData), num.samps)
+    checkEqualsNumeric(length(xsl[[x]]@rt$raw), num.samps)
+  }
+}

--- a/inst/unitTests/runit.splitCombine.R
+++ b/inst/unitTests/runit.splitCombine.R
@@ -32,7 +32,7 @@ testCombine <- function() {
 }
 
 testSplitFactorShort = function() {
-  f = c("1", "2", "2")
+  f = c(1,2,2)
   xsl <- split(faahko, f)
   for (x in unique(f)) {
     num.samps = sum(x==f)
@@ -42,12 +42,12 @@ testSplitFactorShort = function() {
   }
 }
 
-testSplitFactorLong = function() {
-  f = c(1,2, NULL, NULL, NULL, NULL, NULL,1,1,1,1,1,1,1,1,1)
-  f = c("1", "2", "2")
+testSplitFactorLongDrop = function() {
+  f = c(1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3)
+  actual.f = f[1:nrow(faahko@phenoData)]
   xsl <- split(faahko, f)
-  for (x in unique(f)) {
-    num.samps = sum(x==f)
+  for (x in unique(actual.f)) {
+    num.samps = sum(x==actual.f)
     checkEqualsNumeric(length(xsl[[x]]@filepaths), num.samps)
     checkEqualsNumeric(nrow(xsl[[x]]@phenoData), num.samps)
     checkEqualsNumeric(length(xsl[[x]]@rt$raw), num.samps)


### PR DESCRIPTION
spit.xcmsSet fails when length(f) != nrow(x@phenoData).  This should be a drop in replacement that addresses these cases. I also added a few warnings when f is a strange length do avoid future confusion. 

I am a little unsure about how to treat drop=F.  Currently extra factors with no corresponding xcmsSets are empty list items which is what I think the previous behavior was.  I couldn't figure out when I would use this so someone should consider if this is correct.

I've never written a unit test in R before, but the included ones demonstrate the problem, though I'm not sure about the conventions there.