### PR TITLE
Fixed split.xcmsSet in the case of length(f) != nrow(xcmsSet@phenodata)

### DIFF
--- a/R/xcmsSet.R
+++ b/R/xcmsSet.R
@@ -236,28 +236,29 @@ split.xcmsSet <- function(x, f, drop = TRUE, ...) {
 
     lcsets <- vector("list", length(levels(f)))
     names(lcsets) <- levels(f)
-
+    
     for (i in unique(sampidx)) {
+        samptrans = which(sampidx == i)
+        samptrans = samptrans[samptrans <= nrow(x@phenoData)]
+        
+        if (length(samptrans) < 1) next
+        
         lcsets[[i]] <- new("xcmsSet")
-
-        samptrans <- numeric(length(f))
-        samptrans[sampidx == i] <- rank(which(sampidx == i))
-        samp <- samptrans[peakmat[,"sample"]]
-        sidx <- which(samp != 0)
-        cpeaks <- peakmat[sidx,, drop=FALSE]
-        cpeaks[,"sample"] <- samp[sidx]
+        
+        cpeaks = peakmat[peakmat[,"sample"] %in% samptrans, ,drop=F]
+        cpeaks[,"sample"] <- as.numeric(factor(cpeaks[,"sample"]))
         peaks(lcsets[[i]]) <- cpeaks
 
-        sampnames(lcsets[[i]]) <- samples[sampidx == i]
-        sampclass(lcsets[[i]]) <- classlabel[sampidx == i, drop = TRUE]
-        filepaths(lcsets[[i]]) <- cdffiles[sampidx == i]
+        sampnames(lcsets[[i]]) <- samples[samptrans]
+        sampclass(lcsets[[i]]) <- classlabel[samptrans, drop = TRUE]
+        filepaths(lcsets[[i]]) <- cdffiles[samptrans]
         profinfo(lcsets[[i]]) <- prof
-        lcsets[[i]]@rt$raw <- rtraw[sampidx == i]
-        lcsets[[i]]@rt$corrected <- rtcor[sampidx == i]
+        lcsets[[i]]@rt$raw <- rtraw[samptrans]
+        lcsets[[i]]@rt$corrected <- rtcor[samptrans]
     }
 
     if (drop)
-        lcsets <- lcsets[seq(along = lcsets) %in% sampidx]
+        lcsets <- lcsets[!sapply(lcsets, is.null)]
 
     lcsets
 }

--- a/inst/unitTests/runit.splitCombine.R
+++ b/inst/unitTests/runit.splitCombine.R
@@ -30,3 +30,27 @@ testCombine <- function() {
     xsl <- split(faahko,sampclass(faahko))
     checkEqualsNumeric(length(sampnames(c(xsl[[1]], xsl[[2]]))), 12)
 }
+
+
+testSplitFactorShort = function() {
+  f = c(1,2,2)
+  xsl <- split(faahko, f)
+  for (x in unique(f)) {
+    num.samps = sum(x==f)
+    checkEqualsNumeric(length(xsl[[x]]@filepaths), num.samps)
+    checkEqualsNumeric(nrow(xsl[[x]]@phenoData), num.samps)
+    checkEqualsNumeric(length(xsl[[x]]@rt$raw), num.samps)
+  }
+}
+
+testSplitFactorLongDrop = function() {
+  f = c(1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3)
+  actual.f = f[1:nrow(faahko@phenoData)]
+  xsl <- split(faahko, f)
+  for (x in unique(actual.f)) {
+    num.samps = sum(x==actual.f)
+    checkEqualsNumeric(length(xsl[[x]]@filepaths), num.samps)
+    checkEqualsNumeric(nrow(xsl[[x]]@phenoData), num.samps)
+    checkEqualsNumeric(length(xsl[[x]]@rt$raw), num.samps)
+  }
+}


### PR DESCRIPTION
I rewrote my pull request to implement the fix in one commit and in the fewest number of changes possible.  I thought this would be easier to verify.