### PR TITLE
Explicitly enable -O2 optimisation

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,6 +6,9 @@ XCMSOBJECTS=fastMatch.o mzClust_hclust.o mzROI.o util.o xcms.o
 
 OBJECTS= $(MQOBJECTS) $(OBIOBJECTS) $(XCMSOBJECTS)
 
+## As of R-4.3 beta -O2 is not default on Linux.
+PKG_CXXFLAGS=-O2 
+
 all: clean $(SHLIB)
 
 clean:


### PR DESCRIPTION
As of R-4.3 beta -O2 is not default on Linux
Without -O2, R CMD check causes a WARNING. Closes #150