### PR TITLE
Fix issue #184

### DIFF
--- a/R/methods-xcmsSet.R
+++ b/R/methods-xcmsSet.R
@@ -350,7 +350,8 @@ setMethod("group.density", "xcmsSet", function(object, bw = 30, minfrac = 0.5,
                                     minFraction = minfrac,
                                     minSamples = minsamp,
                                     binSize = mzwid,
-                                    maxFeatures = max)
+                                    maxFeatures = max,
+                                    sleep = sleep)
     
     groups(object) <- res$featureDefinitions
     groupidx(object) <- res$peakIndex

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -5,6 +5,8 @@ BUG FIXES:
 - issue #181: problem when isCentroided,Spectrum method returns NA because of
   too few peaks in a spectrum. Fixed by checking in such cases all spectra in
   the file.
+- issue #184: add parameter sleep to do_groupChromPeaks_density function to be
+  backwards compatible with the old group.density code.
 
 
 CHANGES IN VERSION 2.99.1

--- a/man/do_groupChromPeaks_density.Rd
+++ b/man/do_groupChromPeaks_density.Rd
@@ -6,7 +6,7 @@
 grouping}
 \usage{
 do_groupChromPeaks_density(peaks, sampleGroups, bw = 30, minFraction = 0.5,
-  minSamples = 1, binSize = 0.25, maxFeatures = 50)
+  minSamples = 1, binSize = 0.25, maxFeatures = 50, sleep = 0)
 }
 \arguments{
 \item{peaks}{A \code{matrix} or \code{data.frame} with the mz values and
@@ -36,6 +36,9 @@ in mz dimension.}
 
 \item{maxFeatures}{\code{numeric(1)} with the maximum number of peak groups
 to be identified in a single mz slice.}
+
+\item{sleep}{\code{numeric(1)} defining the time to \emph{sleep} between
+iterations and plot the result from the current iteration.}
 }
 \value{
 A \code{list} with elements \code{"featureDefinitions"} and


### PR DESCRIPTION
- Add parameter sleep to the do_groupChromPeaks_density function to ensure
  backward compatibility with the old group.density code.