### PR TITLE
Misplaced parenthesis checking number of spectra

### DIFF
--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -352,7 +352,7 @@ setMethod("findChromPeaks",
                        "peak detection")
 
               rts <- split(rtime(object_mslevel), f = fromFile(object_mslevel))
-              if (any(lengths(rts)) > 1)
+              if (any(lengths(rts) > 1))
                   stop("The MSW method can only be applied to single spectrum,",
                        " non-chromatographic, files (i.e. with a single ",
                        "retention time).")


### PR DESCRIPTION
The wrong check was being performed when looking to see if only a single spectrum was present