### PR TITLE
fix profEIC fails for single scans per peak

### DIFF
--- a/R/functions-xcmsRaw.R
+++ b/R/functions-xcmsRaw.R
@@ -299,7 +299,7 @@ profEIC <- function(object, mzrange, rtrange = NULL, step = 0.1) {
                                                  yes = 0, no = NA),
                               shiftByHalfBinSize = TRUE,
                               sortedX = TRUE)
-            if (length(toIdx) == 1)
+            if (length(binRes) == 1)
                 binRes <- list(binRes)
             bin_size <- binRes[[1]]$x[2] - binRes[[1]]$x[1]
             if (is.null(basespace)) {


### PR DESCRIPTION
binYonX return a binRes  list of length == 1, even if  if length(toIdx) > 1, when a feature is narrow and represented by a single scan. This leads to a list indexing failure for  bin_size calculation.  Fixed by forcing list() of binRes if it has length 1, which will be the case if length(toIdx) == 1 or a feature is represented by  single scan