### PR TITLE
Add plot,XCMSnExp method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Depends:
     BiocParallel (>= 1.8.0),
     MSnbase (>= 2.9.3)
 Imports:
-    mzR (>= 2.13.3),
+    mzR (>= 2.19.5),
     BiocGenerics,
     ProtGenerics (>= 1.17.2),
     lattice,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.7.2
+Version: 3.7.3
 Title: LC/MS and GC/MS Data Analysis
 Authors@R: c(
 	   person(given = "Colin A.", family = "Smith",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -497,5 +497,6 @@ exportMethods("hasChromPeaks",
 	      "writeMSData",
               "plotChromPeakDensity",
               "align",
-              "correlate"
+              "correlate",
+              "plot"
               )

--- a/R/DataClasses.R
+++ b/R/DataClasses.R
@@ -2379,7 +2379,9 @@ setClass("MsFeatureData", contains = c("environment", "Versioned"),
 #' preprocessing results will be passed along to the resulting
 #' \code{xcmsSet} object.
 #'
-#' General functions for \code{XCMSnExp} objects are:
+#' General functions for \code{XCMSnExp} objects are (see further below for
+#' specific function to handle chromatographic peak data, alignment and
+#' correspondence results):
 #'
 #' @section Chromatographic peak data:
 #'
@@ -2499,6 +2501,7 @@ setClass("MsFeatureData", contains = c("environment", "Versioned"),
 #'     For \code{chromPeaks<-}: a \code{matrix} with information on
 #'     detected peaks. See return value for the \code{chromPeaks} method for the
 #'     expected format.
+#'
 #'
 #' @author Johannes Rainer
 #'

--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -3492,3 +3492,28 @@ setReplaceMethod("chromPeakData", "XCMSnExp", function(object, value) {
     validObject(object)
     object
 })
+
+#' @description
+#'
+#' \code{plot} plots the spectrum data (see \code{\link{plot}} for
+#' \code{\link{MSnExp}} objects in the \code{MSnbase} package for more details.
+#' For \code{type = "XIC"}, identified chromatographic peaks will be indicated
+#' as rectangles with border color \code{peakCol}.
+#'
+#' @param x For \code{plot}: \code{XCMSnExp} object.
+#'
+#' @param y For \code{plot}: not used.
+#'
+#' @param peakCol For \code{plot}: the color that should be used to indicate
+#'     identified chromatographic peaks (only in combination with
+#'     \code{type = "XIC"} and if chromatographic peaks are present).
+#'
+#' @rdname XCMSnExp-class
+setMethod("plot", c("XCMSnExp", "missing"),
+          function(x, y, type = c("spectra", "XIC"),
+                   peakCol = "#ff000060", ...) {
+              type <- match.arg(type)
+              if (type == "spectra" || !hasChromPeaks(x))
+                  callNextMethod(x = x, type = type, ...)
+              else .plot_XIC(x, peakCol = peakCol, ...)
+          })

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+Changes in version 3.7.3
+
+- plot type = "XIC" on an XCMSnExp object will draw rectangles indicating the
+  identified chromatographic peaks.
+
+
 Changes in version 3.7.2
 
 - Fix documentation (issue #401).

--- a/man/XCMSnExp-class.Rd
+++ b/man/XCMSnExp-class.Rd
@@ -68,6 +68,7 @@
 \alias{c.XCMSnExp}
 \alias{chromPeakData,XCMSnExp-method}
 \alias{chromPeakData<-,XCMSnExp-method}
+\alias{plot,XCMSnExp,missing-method}
 \title{Data container storing xcms preprocessing results}
 \usage{
 processHistoryTypes()
@@ -140,6 +141,9 @@ hasFilledChromPeaks(object)
 \S4method{chromPeakData}{XCMSnExp}(object)
 
 \S4method{chromPeakData}{XCMSnExp}(object) <- value
+
+\S4method{plot}{XCMSnExp,missing}(x, y, type = c("spectra", "XIC"),
+  peakCol = "#ff000060", ...)
 }
 \arguments{
 \item{object}{For \code{adjustedRtime}, \code{featureDefinitions},
@@ -252,6 +256,14 @@ return. Can be either \code{"XCMSnExp"} (default), \code{"list"} or
 
 \item{FUN}{For \code{spectrapply}: a function that should be applied to each
 spectrum in the object.}
+
+\item{x}{For \code{plot}: \code{XCMSnExp} object.}
+
+\item{y}{For \code{plot}: not used.}
+
+\item{peakCol}{For \code{plot}: the color that should be used to indicate
+identified chromatographic peaks (only in combination with
+\code{type = "XIC"} and if chromatographic peaks are present).}
 }
 \value{
 For \code{profMat}: a \code{list} with a the profile matrix
@@ -340,7 +352,9 @@ objects using the \code{as} method (see examples below). All
 preprocessing results will be passed along to the resulting
 \code{xcmsSet} object.
 
-General functions for \code{XCMSnExp} objects are:
+General functions for \code{XCMSnExp} objects are (see further below for
+specific function to handle chromatographic peak data, alignment and
+correspondence results):
 
 \code{processHistoryTypes} returns the available \emph{types} of
     process histories. These can be passed with argument \code{type} to the
@@ -500,6 +514,11 @@ results. If no function is specified the function simply returns the
 \code{XCMSnExp} objects can be combined with the \code{c} function. This
 combines identified chromatographic peaks and the objects' pheno data but
 discards alignment results or feature definitions.
+
+\code{plot} plots the spectrum data (see \code{\link{plot}} for
+\code{\link{MSnExp}} objects in the \code{MSnbase} package for more details.
+For \code{type = "XIC"}, identified chromatographic peaks will be indicated
+as rectangles with border color \code{peakCol}.
 }
 \section{Slots}{
 

--- a/tests/testthat/test_functions-XCMSnExp.R
+++ b/tests/testthat/test_functions-XCMSnExp.R
@@ -531,3 +531,16 @@ test_that("reconstructChromPeakSpectra works", {
     expect_error(reconstructChromPeakSpectra(pest_swth, peakId = c("a", "b")),
                  "None of the provided")
 })
+
+test_that(".plot_XIC works", {
+    mzr <- c(453, 453.5)
+    rtr <- c(2400, 2700)
+
+    tmp <- filterMz(filterRt(xod_x, rtr), mzr)
+    .plot_XIC(tmp)
+
+    mzr <- c(301.9, 302.1)
+    rtr <- c(2500, 2650)
+    tmp <- filterMz(filterRt(xod_x, rtr), mzr)
+    .plot_XIC(tmp, peakCol = "#ff0000", lwd = 10)
+})

--- a/tests/testthat/test_methods-XCMSnExp.R
+++ b/tests/testthat/test_methods-XCMSnExp.R
@@ -2260,3 +2260,14 @@ test_that("chromPeakData,XCMSnExp works", {
     expect_true(is.character(chromPeakData(res)$other_column))
     expect_true(any(colnames(chromPeakData(res)) == "other_column"))
 })
+
+test_that("plot,XCMSnExp works", {
+    mzr <- c(301.9, 302.1)
+    rtr <- c(2500, 2650)
+    tmp <- filterMz(filterRt(xod_x, rtr), mzr)
+    centroided(tmp) <- TRUE
+
+    plot(tmp[1:3], type = "spectra")
+
+    plot(tmp, type = "XIC")
+})

--- a/tests/testthat/test_old_xcmsSource.R
+++ b/tests/testthat/test_old_xcmsSource.R
@@ -42,5 +42,6 @@ test_that("xcmsSource works", {
     mzR:::rampClose(rid)
     rm(rid)
     rawdata$polarity <- tmp$polarity
+    rawdata$MSn$precursorNum <- tmp$MSn$precursorNum
     expect_equal(rawdata, tmp)
 })

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -258,9 +258,10 @@ be set to accommodate the expected widths of peak in the data set. We set it to
 
 For the `ppm` parameter we extract the full MS data (intensity, retention time
 and m/z values) corresponding to the above peak. To this end we first filter the
-raw object by retention time, then by m/z and finally plot the object with`type =
-"XIC"` to produce the plot below. We use the *pipe* (`%>%`) command better
-illustrate the corresponding workflow.
+raw object by retention time, then by m/z and finally plot the object with `type
+= "XIC"` to produce the plot below. We use the *pipe* (`%>%`) command better
+illustrate the corresponding workflow. Note also that in this type of plot
+identified chromatographic peaks would be indicated by default if present.
 
 ```{r peak-detection-plot-ms-data, message = FALSE, warning = FALSE, fig.aligh = "center", fig.width = 14, fig.height = 14, fig.cap = "Visualization of the raw MS data for one peak. For each plot: upper panel: chromatogram plotting the intensity values against the retention time, lower panel m/z against retention time plot. The individual data points are colored according to the intensity." }
 raw_data %>%


### PR DESCRIPTION
Add a `plot,XCMSnExp` method to support highlighting of identified chromatographic peaks for `type = "XIC"` (https://github.com/lgatto/MSnbase/issues/482).