### PR TITLE
Update methods-XCMSnExp.R

### DIFF
--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -2200,7 +2200,7 @@ setMethod("featureValues",
     nSamples <- seq_along(colnames)
     if (method == "sum") {
         for (i in seq_along(ftIdx)) {
-            cur_pks <- pks[ftIdx[[i]], c(value, "sample")]
+            cur_pks <- pks[ftIdx[[i]], c(value, "sample"), drop=FALSE]
             int_sum <- split(cur_pks[, value], cur_pks[, "sample"])
             vals[i, as.numeric(names(int_sum))] <-
                 unlist(lapply(int_sum, base::sum), use.names = FALSE)


### PR DESCRIPTION
when ftIdx[[i]] (peakidx) is length 1, the resulted cur_pks would be a vector, not a matrix as expect. The next line "cur_pks[, value]" would throw an error message.