### PR TITLE
Added Bioschemas annotation to the xcms.Rmd vignette

### DIFF
--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -4,6 +4,8 @@ package: xcms
 output:
   BiocStyle::html_document:
     toc_float: true
+    includes:
+      in_header: xcms.bioschemas.html
 vignette: >
   %\VignetteIndexEntry{LCMS data preprocessing and analysis with xcms}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/xcms.bioschemas.html
+++ b/vignettes/xcms.bioschemas.html
@@ -1,0 +1,26 @@
+<script type="application/ld+json">
+{
+  "@context":"http://schema.org/",
+  "@type":"CreativeWork",
+  "audience":[
+    "http://edamontology.org/topic_3070",
+    "http://edamontology.org/topic_3314"
+  ],
+  "genre":[
+    "http://edamontology.org/data_2536",
+    "http://edamontology.org/operation_3215"
+  ],
+  "name":"LCMS data preprocessing and analysis with xcms",
+  "author":[{
+    "@type":"Person",
+    "name":"Johannes Rainer",
+    "identifier":"0000-0002-6977-7147"
+  }],
+  "difficultyLevel": "beginner",
+  "keywords":"metabolomics, mass spectrometry",
+  "license":"AGPL-3",
+  "url":[
+    "https://bioconductor.org/packages/release/bioc/vignettes/xcms/inst/doc/xcms.html"
+  ]
+}
+</script>


### PR DESCRIPTION
Adds Bioschemas annotation for one of the vignettes. I suggest one *.bioschemas.html for each vignette. Note how toe xcms.Rmd YAML points to the `xcms.bioschemas.html` file, which contains only a `<script>` element with JSON-LD in it.