### PR TITLE
add missing centroided() export from ProtGenerics

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@ useDynLib(xcms)
 importFrom("utils", "capture.output")
 import("methods")
 importMethodsFrom("ProtGenerics", "peaks", "chromatogram", "writeMSData",
-    "polarity<-", "isCentroided", "peaks<-", "isolationWindowTargetMz")
+    "polarity<-", "centroided", "isCentroided", "peaks<-", "isolationWindowTargetMz")
 importFrom("BiocGenerics", "updateObject", "fileName", "subset",
     "dirname", "dirname<-")
 ## import("Biobase")


### PR DESCRIPTION
Hello,

This PR adds a missing export for the `ProtGenerics::centroided()` method (needed by `findChromPeaks()`), which is needed when XCMS is used without using `library(xcms)` (e.g. from a package). 