### PR TITLE
Bug fix: groupval() failing on object converted from XCMSnExp. Issue 471

### DIFF
--- a/R/methods-xcmsSet.R
+++ b/R/methods-xcmsSet.R
@@ -440,9 +440,17 @@ setMethod("groupval", "xcmsSet", function(object, method = c("medret", "maxint")
     method <- match.arg(method)
     peakmat <- peaks(object)
     groupmat <- groups(object)
+    if ("peakidx" %in% colnames(groupmat)) {
+        groupmat <- groupmat[, !colnames(groupmat) %in% "peakidx"]
+        groupmat <- apply(groupmat, 2, unlist)
+    }
     groupindex <- groupidx(object)
 
     sampnum <- seq(length = length(sampnames(object)))
+    if (length(sampnum) == 0) {
+        sampnum <- unique(object@peaks[, "sample"])
+    }
+    
     retcol <- match("rt", colnames(peakmat))
     intcol <- match(intensity, colnames(peakmat))
     sampcol <- match("sample", colnames(peakmat))

--- a/tests/testthat/test_groupval_xcsmSet_converted_from_XCMSnExp.R
+++ b/tests/testthat/test_groupval_xcsmSet_converted_from_XCMSnExp.R
@@ -1,0 +1,32 @@
+test_that("groupval returns expected output on object converted from XCMSnExp", {
+
+    cdfs <- dir(system.file("cdf", package = "faahKO"), full.names = TRUE,
+        recursive = TRUE)[1:3]
+    xset <- xcmsSet(cdfs, method = 'centWave', ppm = 25, peakwidth = c(20, 80),
+        snthresh = 10, prefilter = c(3,100), integrate = 1, mzdiff = -0.001,
+        verbose.columns = FALSE, fitgauss = FALSE, noise = 5000)
+    xset <- xcms::group(xset, method = "density", bw = 30, minfrac = 0.5,
+        minsamp = 1)
+    
+    raw_data <- readMSData(files = cdfs,
+        pdata = new("NAnnotatedDataFrame"), mode = "onDisk")
+    cwp <- xcms::CentWaveParam(peakwidth = c(20, 80), noise = 5000)
+    xdata <- xcms::findChromPeaks(raw_data, param = cwp)
+    xdata <- xcms::groupChromPeaks(xdata,
+        xcms::PeakDensityParam(sampleGroups = rep("KO", 3)))
+    
+    expect_equivalent(xcms::peaks(xset), xcms::chromPeaks(xdata))
+    expect_equivalent(xcms::groups(xset),
+        as.matrix(xcms::featureDefinitions(xdata)[, 1:8]))
+    
+    expect_true(is(xdata, "XCMSnExp"))
+    
+    # Convert XCMSnExp to xcmsSet
+    xdata <- as(xdata, "xcmsSet")
+    expect_true(is(xdata, "xcmsSet"))
+    
+    expect_equivalent(xcms::peaks(xset), xcms::peaks(xdata))
+    expect_equivalent(xcms::groups(xset), xcms::groups(xdata)[, 1:8])
+    
+    expect_equivalent(groupval(xset), groupval(xdata))
+})


### PR DESCRIPTION
Hi, this is proposed fix for https://github.com/sneumann/xcms/issues/471.

Lines 450 - 453 (https://github.com/andzajan/xcms/blob/master/R/methods-xcmsSet.R#L450-L453) are needed in case if 'phenoData' information is lost during `xset <- as(xset, "xcmsSet")`.

Ping @RJMW, @Tomnl.