### PR TITLE
fix: report rtime for SWATH reconstructed spectra

### DIFF
--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -2514,7 +2514,8 @@ findChromPeaksIsolationWindow <-
 #'
 #' @param expandRt `numeric(1)` allowing to expand the retention time range
 #'     for extracted ion chromatograms by a constant value (for the peak
-#'     shape correlation).
+#'     shape correlation). Defaults to `expandRt = 0` hence correlates only
+#'     the signal included in the identified chromatographic peaks.
 #'
 #' @param diffRt `numeric(1)` defining the maximal allowed difference between
 #'     the retention time of the chromatographic peak (apex) and the retention
@@ -2545,14 +2546,16 @@ findChromPeaksIsolationWindow <-
 #'     and [NumericList()] with length equal to the number of peaks per
 #'     reconstructed MS2 spectrum) providing the IDs and the correlation of the
 #'     MS2 chromatographic peaks from which the MS2 spectrum was reconstructed.
+#'     As retention time the median retention times of all MS2 chromatographic
+#'     peaks used for the spectrum reconstruction is reported.
 #'
-#' @author Johannes Rainer, Micheal Witting
+#' @author Johannes Rainer, Michael Witting
 #'
 #' @md
 #'
 #' @seealso [findChromPeaksIsolationWindow()] for the function to perform MS2
 #'     peak detection in DIA isolation windows and for examples.
-reconstructChromPeakSpectra <- function(object, expandRt = 1, diffRt = 2,
+reconstructChromPeakSpectra <- function(object, expandRt = 0, diffRt = 2,
                                         minCor = 0.8, intensity = "maxo",
                                         peakId = rownames(
                                             chromPeaks(object, msLevel = 1L)),

--- a/R/functions-xcmsSwath.R
+++ b/R/functions-xcmsSwath.R
@@ -142,7 +142,7 @@
     od_object <- filterIsolationWindow(as(object, "OnDiskMSnExp"), mz = x["mz"])
     if (!length(idx) | !length(od_object))
         return(Spectra(
-            new("Spectrum2", fromFile = fromFile),
+            new("Spectrum2", fromFile = fromFile, rt = x["rt"]),
             elementMetadata = DataFrame(
                 ms2_peak_id = CharacterList(character()),
                 ms2_peak_cor = NumericList(numeric()))))
@@ -162,24 +162,24 @@
         chr_2 <- Chromatograms(list(chr_2))
     if (!length(chr_2))
         return(Spectra(
-            new("Spectrum2", fromFile = fromFile),
+            new("Spectrum2", fromFile = fromFile, rt = x["rt"]),
             elementMetadata = DataFrame(
                 ms2_peak_id = CharacterList(character()),
                 ms2_peak_cor = NumericList(numeric()))))
-    cors <- vapply(chr_2@.Data, xcms:::.correlate_chromatogram, y = chr_1[1, 1],
+    cors <- vapply(chr_2@.Data, .correlate_chromatogram, y = chr_1[1, 1],
                    numeric(1), align = "approx")
     pks <- pks[which(cors >= minCor), , drop = FALSE]
     if (nrow(pks)) {
         sp <- new("Spectrum2", fromFile = fromFile, centroided = TRUE,
                   mz = pks[, "mz"], intensity = pks[, column],
-                  precursorMz = x["mz"])
+                  precursorMz = x["mz"], rt = median(pks[, "rt"]))
         df <- DataFrame(matrix(ncol = 0, nrow = 1))
         df$ms2_peak_id <- CharacterList(rownames(pks), compress = FALSE)
         df$ms2_peak_cor <- NumericList(cors[cors >= minCor], compress = FALSE)
         Spectra(sp, elementMetadata = df)
     } else {
         Spectra(
-            new("Spectrum2", fromFile = fromFile),
+            new("Spectrum2", fromFile = fromFile, rt = x["rt"]),
             elementMetadata = DataFrame(
                 ms2_peak_id = CharacterList(character()),
                 ms2_peak_cor = NumericList(numeric())))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,5 +1,8 @@
 Changes in version 3.11.3
 
+- `reconstructChromPeakSpectra`: ensure a retention time is reported for
+  reconstructed MS2 spectra (issue #485).
+- Change default for `expandRt` to `0` in `reconstructChromPeakSpectra`.
 - Fix error in `refineChromPeaks,MergeNeighboringPeaksParam` if no peaks found
   to be merged.
 

--- a/man/reconstructChromPeakSpectra.Rd
+++ b/man/reconstructChromPeakSpectra.Rd
@@ -6,7 +6,7 @@
 \usage{
 reconstructChromPeakSpectra(
   object,
-  expandRt = 1,
+  expandRt = 0,
   diffRt = 2,
   minCor = 0.8,
   intensity = "maxo",
@@ -19,7 +19,8 @@ reconstructChromPeakSpectra(
 
 \item{expandRt}{\code{numeric(1)} allowing to expand the retention time range
 for extracted ion chromatograms by a constant value (for the peak
-shape correlation).}
+shape correlation). Defaults to \code{expandRt = 0} hence correlates only
+the signal included in the identified chromatographic peaks.}
 
 \item{diffRt}{\code{numeric(1)} defining the maximal allowed difference between
 the retention time of the chromatographic peak (apex) and the retention
@@ -51,6 +52,8 @@ columns \code{"ms2_peak_id"} and \code{"ms2_peak_cor"} (of type \code{\link[=Cha
 and \code{\link[=NumericList]{NumericList()}} with length equal to the number of peaks per
 reconstructed MS2 spectrum) providing the IDs and the correlation of the
 MS2 chromatographic peaks from which the MS2 spectrum was reconstructed.
+As retention time the median retention times of all MS2 chromatographic
+peaks used for the spectrum reconstruction is reported.
 }
 \description{
 Reconstructs MS2 spectra for each MS1 chromatographic peak (if possible) for
@@ -81,5 +84,5 @@ chromatographic peaks for each spectrum as well as their correlation value.
 peak detection in DIA isolation windows and for examples.
 }
 \author{
-Johannes Rainer, Micheal Witting
+Johannes Rainer, Michael Witting
 }

--- a/tests/testthat/test_functions-xcmsSwath.R
+++ b/tests/testthat/test_functions-xcmsSwath.R
@@ -27,11 +27,12 @@ test_that(".which_chrom_peak_diff_rt works", {
 test_that(".reconstruct_ms2_for_chrom_peak works", {
     ## Fluopicolide, exact mass = 381.965430576, [M+H]+ = 382.972706
     pk <- chromPeaks(pest_swth, mz = 382.972706, ppm = 10)
-    res <- .reconstruct_ms2_for_chrom_peak(pk, pest_swth, fromFile = 7L,
+    res <- xcms:::.reconstruct_ms2_for_chrom_peak(pk, pest_swth, fromFile = 7L,
                                            expandRt = 3, diffRt = 2,
                                            minCor = 0.8)
     expect_true(is(res, "Spectra"))
     expect_equal(unname(fromFile(res)), 7L)
+    expect_true(!is.na(rtime(res)))
     expect_equal(length(mcols(res)$ms2_peak_id[[1]]), 14)
     expect_true(all(mcols(res)$ms2_peak_cor[[1]] > 0.8))
     expect_equal(length(intensity(res[[1]])), 14)

--- a/vignettes/xcms-lcms-ms.Rmd
+++ b/vignettes/xcms-lcms-ms.Rmd
@@ -405,22 +405,17 @@ fenamiphos_ms2_peak <- chromPeaks(swath_data)[which(keep), ]
 
 In total `r sum(keep, na.rm = TRUE)` MS2 chromatographic peaks match all the
 above condition. Next we extract their corresponding ion chromatograms, as well
-as the ion chromatogram of the MS1 peak. Note that we extend the retention time
-range by 1 seconds on both sides. In addition we have to filter the object
-first by isolation window, keeping only spectra that were measured in that
-specific window and to specify to extract the chromatographic data from MS2
+as the ion chromatogram of the MS1 peak. In addition we have to filter the
+object first by isolation window, keeping only spectra that were measured in
+that specific window and to specify to extract the chromatographic data from MS2
 spectra (with `msLevel = 2L`).
 
 ```{r fena-eic-extract, warning = FALSE}
 rtr <- fenamiphos_ms1_peak[, c("rtmin", "rtmax")]
-rtr[1] <- rtr[1] - 1
-rtr[2] <- rtr[2] + 1
 mzr <- fenamiphos_ms1_peak[, c("mzmin", "mzmax")]
 fenamiphos_ms1_chr <- chromatogram(swath_data, rt = rtr, mz = mzr)
 
 rtr <- fenamiphos_ms2_peak[, c("rtmin", "rtmax")]
-rtr[, 1] <- rtr[, 1] - 1
-rtr[, 2] <- rtr[, 2] + 1
 mzr <- fenamiphos_ms2_peak[, c("mzmin", "mzmax")]
 fenamiphos_ms2_chr <- chromatogram(
     filterIsolationWindow(swath_data, mz = fenamiphos_mz),
@@ -522,8 +517,6 @@ because `chromatogram` extracts by default only data from MS1 spectra.
 
 ```{r}
 rt_range <- chromPeaks(swath_data)[pk_ids, c("rtmin", "rtmax")]
-rt_range[, 1] <- rt_range[, 1] - 1
-rt_range[, 2] <- rt_range[, 2] + 1
 mz_range <- chromPeaks(swath_data)[pk_ids, c("mzmin", "mzmax")]
 
 pmz <- precursorMz(fenamiphos_swath_spectrum)[1]


### PR DESCRIPTION
- `reconstructChromPeakSpectra` reports the median rt of all MS2 chromatographic
  peaks from which the MS2 spectrum was reconstructed as its retention
  time (issue #485).
- Change default for `expandRt` in `reconstructChromPeakSpectra` to
  `expandRt = 0` to ensure that only signal of identified chromatographic peaks
  is used in the correlation.