### PR TITLE
Small updates and example performance improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.11.6
+Version: 3.11.7
 Title: LC-MS and GC-MS Data Analysis
 Authors@R: c(
 	   person(given = "Colin A.", family = "Smith",

--- a/R/DataClasses.R
+++ b/R/DataClasses.R
@@ -1491,6 +1491,9 @@ NULL
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' res <- faahko_sub
 #'
 #' head(chromPeaks(res))
@@ -1614,6 +1617,9 @@ NULL
 #' fticrf <- list.files(system.file("fticr", package = "msdata"),
 #'                     recursive = TRUE, full.names = TRUE)
 #' fticr <- readMSData(fticrf[1:2], msLevel. = 1, mode = "onDisk")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Perform the MSW peak detection on these:
 #' p <- MSWParam(scales = c(1, 7), peakThr = 80000, ampTh = 0.005,
@@ -1740,6 +1746,9 @@ NULL
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #' res <- faahko_sub
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' head(chromPeaks(res))
 #' ## The number of peaks identified per sample:
@@ -1958,6 +1967,9 @@ NULL
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #' res <- faahko_sub
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' head(chromPeaks(res))
 #' ## The number of peaks identified per sample:
 #' table(chromPeaks(res)[, "sample"])
@@ -2172,6 +2184,9 @@ NULL
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Perform retention time correction:
 #' res <- adjustRtime(faahko_sub, param = ObiwarpParam())
@@ -2516,6 +2531,9 @@ setClass("MsFeatureData", contains = c("environment", "Versioned"),
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## The results from the peak detection are now stored in the XCMSnExp
 #' ## object

--- a/R/do_groupChromPeaks-functions.R
+++ b/R/do_groupChromPeaks-functions.R
@@ -67,6 +67,9 @@
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Extract the matrix with the identified peaks from the xcmsSet:
 #' pks <- chromPeaks(faahko_sub)
 #'

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -150,18 +150,20 @@ findPeaks_MSW_Spectrum_list <- function(x, method = "MSW", param) {
         ionSource = x@experimentData@ionSource[1],
         analyser = x@experimentData@analyser[1],
         detectorType = x@experimentData@detectorType[1])
+    a <- new(to_class)
     create_object <- function(x, i, to_class) {
-        a <- new(to_class)
-        a@processingData@files <- procd@files[i]
-        a@featureData <- extractROWS(
+        slot(procd, "files", check = FALSE) <- x@processingData@files[i]
+        slot(a, "processingData", check = FALSE) <- procd
+        slot(a, "featureData", check = FALSE) <- extractROWS(
             x@featureData, which(x@featureData$msLevel %in% msLevel. &
                                  x@featureData$fileIdx == i))
         if (!nrow(a@featureData))
             stop("No MS level ", msLevel., " spectra present.", call. = FALSE)
         a@featureData$fileIdx <- 1L
-        a@experimentData <- expd
-        a@spectraProcessingQueue <- x@spectraProcessingQueue
-        a@phenoData <- x@phenoData[i, , drop = FALSE]
+        slot(a, "experimentData", check = FALSE) <- expd
+        slot(a, "spectraProcessingQueue", check = FALSE) <-
+            x@spectraProcessingQueue
+        slot(a, "phenoData", check = FALSE) <- x@phenoData[i, , drop = FALSE]
         a
     }
     if (to_class == "XCMSnExp" && is(x, "XCMSnExp") && hasChromPeaks(x)) {
@@ -190,13 +192,13 @@ findPeaks_MSW_Spectrum_list <- function(x, method = "MSW", param) {
                 chromPeakData(newFd) <- .chrom_peak_data(x@msFeatureData)[0, ]
             }
             lockEnvironment(newFd, bindings = TRUE)
-            a@msFeatureData <- newFd
+            slot(a, "msFeatureData", check = FALSE) <- newFd
             res[[i]] <- a
         }
         res
     } else {
         lapply(seq_along(fileNames(x)), function(z) {
-            a <- create_object(x, z, to_class)
+            create_object(x, z, to_class)
         })
     }
 }

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -661,6 +661,9 @@ adjustRtimePeakGroups <- function(object, param = PeakGroupsParam(),
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Performing the peak grouping using the "peak density" method.
 #' p <- PeakDensityParam(sampleGroups = c(1, 1, 1))
 #' res <- groupChromPeaks(faahko_sub, param = p)
@@ -957,6 +960,9 @@ plotAdjustedRtime <- function(object, col = "#00000080", lty = 1, lwd = 1,
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Extract the ion chromatogram for one chromatographic peak in the data.
 #' chrs <- chromatogram(faahko_sub, rt = c(2700, 2900), mz = 335)
@@ -1289,6 +1295,9 @@ isCalibrated <- function(object) {
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' xod <- adjustRtime(faahko_sub, param = ObiwarpParam())
 #'
 #' hasAdjustedRtime(xod)
@@ -1565,6 +1574,9 @@ featureSummary <- function(x, group, perSampleCounts = FALSE,
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Correspondence analysis
 #' xdata <- groupChromPeaks(faahko_sub, param = PeakDensityParam(sampleGroups = c(1, 1, 1)))
@@ -2085,6 +2097,9 @@ featureSpectra <- function(x, msLevel = 2, expandRt = 0, expandMz = 0,
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Subset the object to a smaller retention time range
 #' xdata <- filterRt(faahko_sub, c(2500, 3500))

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -1724,7 +1724,7 @@ ms2_spectra_for_all_peaks <- function(x, expandRt = 0, expandMz = 0,
     file_factor <- factor(pks[, "sample"])
     peak_ids <- rownames(pks)
     pks <- split.data.frame(pks, f = file_factor)
-    x <- .split_by_file(
+    x <- .split_by_file2(
         x, msLevel. = 2L, subsetFeatureData = FALSE)[as.integer(levels(file_factor))]
     res <- bpmapply(ms2_spectra_for_peaks_from_file, x, pks,
                     MoreArgs = list(method = method), SIMPLIFY = FALSE,
@@ -2476,7 +2476,8 @@ reconstructChromPeakSpectra <- function(object, expandRt = 0, diffRt = 2,
                                          "isolationWindowLowerOffset",
                                          "isolationWindowUpperOffset"))
     sps <- bplapply(
-        .split_by_file(object, subsetFeatureData = FALSE, to_class = "XCMSnExp"),
+        .split_by_file2(
+            object, subsetFeatureData = FALSE, to_class = "XCMSnExp"),
         FUN = function(x, files, expandRt, diffRt, minCor, col, pkId) {
             .reconstruct_ms2_for_peaks_file(
                 x, expandRt = expandRt, diffRt = diffRt,

--- a/R/methods-MChromatograms.R
+++ b/R/methods-MChromatograms.R
@@ -10,6 +10,9 @@
 #'     system.file("cdf/KO/ko18.CDF", package = "faahKO")),
 #'     mode = "onDisk")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Extract chromatograms for a m/z - retention time slice
 #' chrs <- chromatogram(od3, mz = 344, rt = c(2500, 3500))
 #'

--- a/R/methods-OnDiskMSnExp.R
+++ b/R/methods-OnDiskMSnExp.R
@@ -78,7 +78,7 @@ setMethod("findChromPeaks",
               if (is.na(centroided) || !centroided)
                   warning("Your data appears to be not centroided! CentWave",
                           " works best on data in centroid mode.")
-              resList <- bplapply(.split_by_file(object, msLevel. = msLevel),
+              resList <- bplapply(.split_by_file2(object, msLevel. = msLevel),
                                   FUN = findChromPeaks_OnDiskMSnExp,
                                   method = "centWave",
                                   param = param, BPPARAM = BPPARAM)
@@ -145,7 +145,7 @@ setMethod("findChromPeaks",
               if (length(msLevel) > 1)
                   stop("Currently only peak detection in a single MS level is ",
                        "supported")
-              resList <- bplapply(.split_by_file(object, msLevel. = msLevel),
+              resList <- bplapply(.split_by_file2(object, msLevel. = msLevel),
                                   FUN = findChromPeaks_OnDiskMSnExp,
                                   method = "matchedFilter",
                                   param = param,
@@ -238,7 +238,7 @@ setMethod("findChromPeaks",
               if (length(msLevel) > 1)
                   stop("Currently only peak detection in a single MS level is ",
                        "supported")
-              resList <- bplapply(.split_by_file(object, msLevel. = msLevel),
+              resList <- bplapply(.split_by_file2(object, msLevel. = msLevel),
                                   FUN = findChromPeaks_OnDiskMSnExp,
                                   method = "massifquant", param = param,
                                   BPPARAM = BPPARAM)
@@ -318,7 +318,7 @@ setMethod("findChromPeaks",
                   stop("The MSW method can only be applied to single spectrum,",
                        " non-chromatographic, files (i.e. with a single ",
                        "retention time).")
-              resList <- bplapply(.split_by_file(object_mslevel),
+              resList <- bplapply(.split_by_file2(object_mslevel),
                                   FUN = findPeaks_MSW_OnDiskMSnExp,
                                   method = "MSW", param = param,
                                   BPPARAM = BPPARAM)
@@ -390,7 +390,7 @@ setMethod("findChromPeaks",
               if (is.na(centroided) || !centroided)
                   warning("Your data appears to be not centroided! CentWave",
                           " works best on data in centroid mode.")
-              resList <- bplapply(.split_by_file(object, msLevel. = msLevel),
+              resList <- bplapply(.split_by_file2(object, msLevel. = msLevel),
                                   FUN = findChromPeaks_OnDiskMSnExp,
                                   method = "centWaveWithPredIsoROIs",
                                   param = param, BPPARAM = BPPARAM)

--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -1149,6 +1149,9 @@ setMethod("filterAcquisitionNum", "XCMSnExp", function(object, n, file) {
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Subset the dataset to the first and third file.
 #' xod_sub <- filterFile(faahko_sub, file = c(1, 3))
 #'
@@ -2350,6 +2353,9 @@ setMethod("featureValues", "XCMSnExp", function(object, method = c("medret",
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Extract the ion chromatogram for one chromatographic peak in the data.
 #' chrs <- chromatogram(faahko_sub, rt = c(2700, 2900), mz = 335)
 #'
@@ -2707,6 +2713,9 @@ setMethod("findChromPeaks",
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #' res <- faahko_sub
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Perform the correspondence. We assign all samples to the same group.
 #' res <- groupChromPeaks(res,
@@ -3254,6 +3263,9 @@ setMethod("dropFilledChromPeaks", "XCMSnExp", function(object) {
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Extract the full MS data for a certain retention time range
 #' ## as a data.frame
 #' tmp <- filterRt(faahko_sub, rt = c(2800, 2900))
@@ -3756,6 +3768,9 @@ setMethod("plot", c("XCMSnExp", "missing"),
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Distribution of chromatographic peak widths
 #' quantile(chromPeaks(faahko_sub)[, "rtmax"] - chromPeaks(faahko_sub)[, "rtmin"])
 #'
@@ -3917,6 +3932,9 @@ setMethod("refineChromPeaks", c(object = "XCMSnExp", param = "CleanPeaksParam"),
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 #'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
+#'
 #' ## Subset to a single file
 #' xd <- filterFile(faahko_sub, file = 1)
 #'
@@ -4050,6 +4068,9 @@ setMethod("refineChromPeaks", c(object = "XCMSnExp",
 #' data(faahko_sub)
 #' ## Update the path to the files for the local system
 #' dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
+#'
+#' ## Disable parallel processing for this example
+#' register(SerialParam())
 #'
 #' ## Remove all peaks with a maximal intensity below 50000
 #' res <- refineChromPeaks(faahko_sub, param = FilterIntensityParam(threshold = 50000))

--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -3952,10 +3952,10 @@ setMethod("refineChromPeaks", c(object = "XCMSnExp",
               }
               validObject(param)
               peak_count <- nrow(chromPeaks(object))
-              res <- bplapply(.split_by_file(object, msLevel. = msLevel,
-                                             to_class = "XCMSnExp",
-                                             subsetFeatureData = TRUE,
-                                             keep_sample_idx = TRUE),
+              res <- bplapply(.split_by_file2(object, msLevel. = msLevel,
+                                              to_class = "XCMSnExp",
+                                              subsetFeatureData = TRUE,
+                                              keep_sample_idx = TRUE),
                               FUN = .merge_neighboring_peaks,
                               expandRt = param@expandRt,
                               expandMz = param@expandMz, ppm = param@ppm,
@@ -4088,8 +4088,8 @@ setMethod("refineChromPeaks", c(object = "XCMSnExp",
                   keep <- chromPeaks(object)[, param@value] >= param@threshold |
                       !chromPeakData(object)$ms_level %in% msLevel
               } else {
-                  res <- bplapply(.split_by_file(object, to_class = "XCMSnExp",
-                                                 msLevel = 1:10),
+                  res <- bplapply(.split_by_file2(object, to_class = "XCMSnExp",
+                                                  msLevel = 1:10),
                                   FUN = .chrom_peaks_above_threshold,
                                   nValues = param@nValues,
                                   threshold = param@threshold,

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,7 @@
 Changes in version 3.11.7
 
 - More efficient splitting data per file especially for larger data sets.
+- Disable parallel processing in examples.
 
 
 Changes in version 3.11.6

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,6 @@
+Changes in version 3.11.7
+
+
 Changes in version 3.11.6
 
 - Add `FilterIntensityParam` to filter chromatographic peaks on intensity

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,5 +1,7 @@
 Changes in version 3.11.7
 
+- More efficient splitting data per file especially for larger data sets.
+
 
 Changes in version 3.11.6
 

--- a/man/XCMSnExp-class.Rd
+++ b/man/XCMSnExp-class.Rd
@@ -682,6 +682,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## The results from the peak detection are now stored in the XCMSnExp
 ## object
 faahko_sub

--- a/man/XCMSnExp-filter-methods.Rd
+++ b/man/XCMSnExp-filter-methods.Rd
@@ -186,6 +186,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Subset the dataset to the first and third file.
 xod_sub <- filterFile(faahko_sub, file = c(1, 3))
 

--- a/man/adjustRtime-obiwarp.Rd
+++ b/man/adjustRtime-obiwarp.Rd
@@ -319,6 +319,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Perform retention time correction:
 res <- adjustRtime(faahko_sub, param = ObiwarpParam())
 

--- a/man/adjustRtime-peakGroups.Rd
+++ b/man/adjustRtime-peakGroups.Rd
@@ -290,6 +290,9 @@ data(faahko_sub)
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 res <- faahko_sub
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 head(chromPeaks(res))
 ## The number of peaks identified per sample:
 table(chromPeaks(res)[, "sample"])

--- a/man/applyAdjustedRtime.Rd
+++ b/man/applyAdjustedRtime.Rd
@@ -38,6 +38,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 xod <- adjustRtime(faahko_sub, param = ObiwarpParam())
 
 hasAdjustedRtime(xod)

--- a/man/chromatogram-method.Rd
+++ b/man/chromatogram-method.Rd
@@ -110,6 +110,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Extract the ion chromatogram for one chromatographic peak in the data.
 chrs <- chromatogram(faahko_sub, rt = c(2700, 2900), mz = 335)
 

--- a/man/do_groupChromPeaks_density.Rd
+++ b/man/do_groupChromPeaks_density.Rd
@@ -91,6 +91,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Extract the matrix with the identified peaks from the xcmsSet:
 pks <- chromPeaks(faahko_sub)
 

--- a/man/extractMsData-method.Rd
+++ b/man/extractMsData-method.Rd
@@ -59,6 +59,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Extract the full MS data for a certain retention time range
 ## as a data.frame
 tmp <- filterRt(faahko_sub, rt = c(2800, 2900))

--- a/man/featureChromatograms.Rd
+++ b/man/featureChromatograms.Rd
@@ -85,6 +85,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Subset the object to a smaller retention time range
 xdata <- filterRt(faahko_sub, c(2500, 3500))
 

--- a/man/fillChromPeaks.Rd
+++ b/man/fillChromPeaks.Rd
@@ -236,6 +236,9 @@ data(faahko_sub)
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 res <- faahko_sub
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Perform the correspondence. We assign all samples to the same group.
 res <- groupChromPeaks(res,
     param = PeakDensityParam(sampleGroups = rep(1, length(fileNames(res)))))

--- a/man/findChromPeaks-Chromatogram-CentWaveParam.Rd
+++ b/man/findChromPeaks-Chromatogram-CentWaveParam.Rd
@@ -72,6 +72,9 @@ od3 <- readMSData(c(system.file("cdf/KO/ko15.CDF", package = "faahKO"),
     system.file("cdf/KO/ko18.CDF", package = "faahKO")),
     mode = "onDisk")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Extract chromatograms for a m/z - retention time slice
 chrs <- chromatogram(od3, mz = 344, rt = c(2500, 3500))
 

--- a/man/groupChromPeaks-density.Rd
+++ b/man/groupChromPeaks-density.Rd
@@ -199,6 +199,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 res <- faahko_sub
 
 head(chromPeaks(res))

--- a/man/groupChromPeaks-mzClust.Rd
+++ b/man/groupChromPeaks-mzClust.Rd
@@ -149,6 +149,9 @@ fticrf <- list.files(system.file("fticr", package = "msdata"),
                     recursive = TRUE, full.names = TRUE)
 fticr <- readMSData(fticrf[1:2], msLevel. = 1, mode = "onDisk")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Perform the MSW peak detection on these:
 p <- MSWParam(scales = c(1, 7), peakThr = 80000, ampTh = 0.005,
              SNR.method = "data.mean", winSize.noise = 500)

--- a/man/groupChromPeaks-nearest.Rd
+++ b/man/groupChromPeaks-nearest.Rd
@@ -169,6 +169,9 @@ data(faahko_sub)
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 res <- faahko_sub
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 head(chromPeaks(res))
 ## The number of peaks identified per sample:
 table(chromPeaks(res)[, "sample"])

--- a/man/highlightChromPeaks.Rd
+++ b/man/highlightChromPeaks.Rd
@@ -77,6 +77,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Extract the ion chromatogram for one chromatographic peak in the data.
 chrs <- chromatogram(faahko_sub, rt = c(2700, 2900), mz = 335)
 

--- a/man/overlappingFeatures.Rd
+++ b/man/overlappingFeatures.Rd
@@ -39,6 +39,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Correspondence analysis
 xdata <- groupChromPeaks(faahko_sub, param = PeakDensityParam(sampleGroups = c(1, 1, 1)))
 

--- a/man/plotAdjustedRtime.Rd
+++ b/man/plotAdjustedRtime.Rd
@@ -72,6 +72,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Performing the peak grouping using the "peak density" method.
 p <- PeakDensityParam(sampleGroups = c(1, 1, 1))
 res <- groupChromPeaks(faahko_sub, param = p)

--- a/man/refineChromPeaks-clean.Rd
+++ b/man/refineChromPeaks-clean.Rd
@@ -43,6 +43,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Distribution of chromatographic peak widths
 quantile(chromPeaks(faahko_sub)[, "rtmax"] - chromPeaks(faahko_sub)[, "rtmin"])
 

--- a/man/refineChromPeaks-filter-intensity.Rd
+++ b/man/refineChromPeaks-filter-intensity.Rd
@@ -60,6 +60,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Remove all peaks with a maximal intensity below 50000
 res <- refineChromPeaks(faahko_sub, param = FilterIntensityParam(threshold = 50000))
 

--- a/man/refineChromPeaks-merge.Rd
+++ b/man/refineChromPeaks-merge.Rd
@@ -126,6 +126,9 @@ data(faahko_sub)
 ## Update the path to the files for the local system
 dirname(faahko_sub) <- system.file("cdf/KO", package = "faahKO")
 
+## Disable parallel processing for this example
+register(SerialParam())
+
 ## Subset to a single file
 xd <- filterFile(faahko_sub, file = 1)
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,13 +3,13 @@ library(xcms)
 library(faahKO)
 library(msdata)
 
-## if (.Platform$OS.type == "unix") {
-##     prm <- MulticoreParam(3)
-## } else {
-##     prm <- SnowParam(3)
-## }
-## register(bpstart(prm))
-register(SerialParam())
+if (.Platform$OS.type == "unix") {
+    prm <- MulticoreParam(3)
+} else {
+    prm <- SnowParam(3)
+}
+register(bpstart(prm))
+## register(SerialParam())
 
 ## Create some objects we can re-use in different tests:
 faahko_3_files <- c(system.file('cdf/KO/ko15.CDF', package = "faahKO"),

--- a/tests/testthat/test_functions-OnDiskMSnExp.R
+++ b/tests/testthat/test_functions-OnDiskMSnExp.R
@@ -76,20 +76,25 @@ test_that(".concatenate_OnDiskMSnExp works", {
     expect_equal(.concatenate_OnDiskMSnExp(od1), od1)
 })
 
-test_that(".split_by_file works", {
+test_that(".split_by_file and .split_bu_file2 work", {
     a <- lapply(seq_along(fileNames(od_x)), filterFile, object = od_x)
     b <- .split_by_file(od_x, subsetFeatureData = FALSE)
     expect_equal(a[[2]][[19]], b[[2]][[19]])
     expect_equal(spectra(a[[3]]), spectra(b[[3]]))
+    d <- .split_by_file2(od_x, subsetFeatureData = FALSE)
+    expect_equal(b, d)
 
     b_2 <- .split_by_file(od_x, subsetFeatureData = TRUE)
     expect_true(ncol(fData(b_2[[1]])) < ncol(fData(b[[1]])))
+    d_2 <- .split_by_file2(od_x, subsetFeatureData = TRUE)
 
     res <- .split_by_file(xod_xgr)
     expect_true(length(res) == 3)
     expect_equal(rtime(res[[2]]),
                  rtime(xod_xgr, bySample = TRUE, adjusted = TRUE)[[2]])
     expect_true(ncol(fData(res[[1]])) < ncol(fData(xod_xgr)))
+    res_2 <- .split_by_file(xod_xgr, subsetFeatureData = TRUE)
+    expect_equal(res, res_2)
     expect_error(.split_by_file(xod_xgr, msLevel. = 2), "No MS level")
 
     a <- filterFile(xod_xgrg, 2, keepAdjustedRtime = TRUE)
@@ -98,6 +103,9 @@ test_that(".split_by_file works", {
     expect_true(is(b[[1]], "XCMSnExp"))
     expect_equal(chromPeaks(a), chromPeaks(b[[2]]))
     expect_equal(chromPeakData(a), chromPeakData(b[[2]]))
+    d <- .split_by_file2(xod_xgrg, to_class = "XCMSnExp",
+                         subsetFeatureData = TRUE)
+    expect_equal(b, d)
 })
 
 test_that(".estimate_prec_intensity works", {

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -38,13 +38,13 @@ library(BiocStyle)
 library(xcms)
 library(faahKO)
 library(pander)
-## ## Use socket based parallel processing on Windows systems
-## if (.Platform$OS.type == "unix") {
-##     register(bpstart(MulticoreParam(3)))
-## } else {
-##     register(bpstart(SnowParam(3)))
-## }
-register(SerialParam())
+## Use socket based parallel processing on Windows systems
+if (.Platform$OS.type == "unix") {
+    register(bpstart(MulticoreParam(3)))
+} else {
+    register(bpstart(SnowParam(3)))
+}
+## register(SerialParam())
 
 ```
 

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -906,7 +906,7 @@ apply(featureValues(xdata), MARGIN = 2,
 
 ```
 
-```{r export-result, eval = TRUE, echo = FALSE}
+```{r export-result, eval = FALSE, echo = FALSE}
 save(xdata, file = "xdata.RData")
 ```
 
@@ -1200,18 +1200,6 @@ x_list <- split(xdata, f = fromFile(xdata), keepAdjustedRtime = TRUE)
 lengths(x_list)
 
 lapply(x_list, hasAdjustedRtime)
-```
-
-Note however that there is also a dedicated `splitByFile` method instead for
-that operation, that internally uses `filterFile` and hence does e.g. not remove
-identified chromatographic peaks. The method does not yet support the
-`keepAdjustedRtime` parameter and thus removes by default adjusted retention
-times.
-
-```{r subset-split-by-file, message = FALSE }
-xdata_by_file <- splitByFile(xdata, f = factor(1:length(fileNames(xdata))))
-
-lapply(xdata_by_file, hasChromPeaks)
 ```
 
 


### PR DESCRIPTION
This PR mainly reduces the runtime of examples (specifically on Windows) by disabling parallel processing (spawning a parallel process in Windows takes much longer than the actual call).

This should fix any build timeouts on the BioC build machines.