### PR TITLE
SSgauss: update for R 4.1

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -1,4 +1,4 @@
-SSgauss <- selfStart(~ h*exp(-(x-mu)^2/(2*sigma^2)), function(mCall, data, LHS) {
+SSgauss <- selfStart(~ h*exp(-(x-mu)^2/(2*sigma^2)), function(mCall, data, LHS, ...) {
 
     xy <- sortedXyData(mCall[["x"]], LHS, data)
 


### PR DESCRIPTION
Hi guys,

Small compatibility update for R 4.1:

```nls() now passes the trace and control arguments to getInitial(), notably for all self-starting models, so these can also be fit in zero-noise situations via a scaleOffset. For this reason, the initial function of a selfStart model must now have ... in its argument list.```

Thanks,
Rick