### PR TITLE
Disable testing on windows i386 and Disable parallel processing on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.15.4
+Version: 3.15.5
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,8 @@
+Changes in version 3.15.5
+
+- Disable testing on windows i386, providing some speedup
+- Disable parallel processing on Windows, causing an issue in testthat on BioC build check  
+
 Changes in version 3.15.4
 
 - Fix in `plot` with `type = "XIC"` to plot an empty plot if no data is present.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -6,10 +6,10 @@ library(msdata)
 if (.Platform$OS.type == "unix") {
     prm <- MulticoreParam(3)
 } else {
-    prm <- SnowParam(3)
+    # prm <- SnowParam(3)
+    prm <- SerialParam()
 }
 register(bpstart(prm))
-## register(SerialParam())
 
 ## Create some objects we can re-use in different tests:
 faahko_3_files <- c(system.file('cdf/KO/ko15.CDF', package = "faahKO"),
@@ -64,3 +64,6 @@ pest_dda <- findChromPeaks(pest_dda, param = cwp)
 ## sciex_data <- pickPeaks(sciex_data)
 
 test_check("xcms")
+
+bpstop(prm)
+

--- a/tests/testthat/test_Chromatogram.R
+++ b/tests/testthat/test_Chromatogram.R
@@ -1,10 +1,14 @@
 ## test_that("extractChromatograms is deprecated", {
+    skip_on_os(os = "windows", arch = "i386")
+
 ##     expect_warning(chrs <- extractChromatograms(
 ##                        filterRt(filterFile(od_x, file = 2), c(2500, 2600))))
 ##     expect_warning(plotChromatogram(chrs))
 ## })
 
 test_that("chromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## OnDiskMSnExp
     ## TIC
     od_tmp <- filterFile(filterRt(od_x, c(2500, 3000)), file = 2)

--- a/tests/testthat/test_MsFeatureData.R
+++ b/tests/testthat/test_MsFeatureData.R
@@ -1,4 +1,6 @@
 test_that("MsFeatureData class validation works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fd <- new("MsFeatureData")
     ## Check error for wrong elements.
     fd$a <- 5
@@ -70,6 +72,8 @@ test_that("MsFeatureData class validation works", {
 })
 
 test_that("MsFeatureData class_accessors work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fd <- new("MsFeatureData")
     expect_true(!hasChromPeaks(fd))
     expect_true(!hasAdjustedRtime(fd))

--- a/tests/testthat/test_Param_classes.R
+++ b/tests/testthat/test_Param_classes.R
@@ -1,4 +1,6 @@
 test_that("CentWaveParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- new("CentWaveParam")
     checkDefaultValues <- function(x) {
         expect_equal(x@ppm, 25)
@@ -71,6 +73,8 @@ test_that("CentWaveParam works", {
 })
 
 test_that("MatchedFilterParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- new("MatchedFilterParam")
     checkDefaultValues <- function(x) {
         expect_equal(x@binSize, 0.1)
@@ -157,6 +161,8 @@ test_that("MatchedFilterParam works", {
 })
 
 test_that("MassifquantParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("MassifquantParam")
     ppm(p) <- 1
@@ -237,6 +243,8 @@ test_that("MassifquantParam works", {
 })
 
 test_that("MSWParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("MSWParam", snthresh = 14)
     expect_equal(snthresh(p), 14)
@@ -337,6 +345,8 @@ test_that("MSWParam works", {
 })
 
 test_that("CentWavePredIsoParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("CentWavePredIsoParam", ppm = 14)
     expect_equal(ppm(p), 14)
@@ -473,6 +483,8 @@ test_that("CentWavePredIsoParam works", {
 })
 
 test_that("PeakDensityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("PeakDensityParam", sampleGroups = c(1, 1, 1, 2, 2, 3, 4))
     expect_equal(sampleGroups(p), c(1, 1, 1, 2, 2, 3, 4))
@@ -533,6 +545,8 @@ test_that("PeakDensityParam works", {
 })
 
 test_that("MzClustParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("MzClustParam", sampleGroups = c(1, 1, 1, 2, 2, 3, 4))
     expect_equal(sampleGroups(p), c(1, 1, 1, 2, 2, 3, 4))
@@ -579,6 +593,8 @@ test_that("MzClustParam works", {
 })
 
 test_that("NearestPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("NearestPeaksParam", sampleGroups = c(1, 1, 1, 2, 2, 3, 4))
     expect_equal(sampleGroups(p), c(1, 1, 1, 2, 2, 3, 4))
@@ -625,6 +641,8 @@ test_that("NearestPeaksParam works", {
 })
 
 test_that("PeakGroupsParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("PeakGroupsParam", minFraction = 0.8)
     expect_equal(minFraction(p), 0.8)
@@ -696,6 +714,8 @@ test_that("PeakGroupsParam works", {
 })
 
 test_that("ObiwarpParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("ObiwarpParam", binSize = 0.8)
     expect_equal(binSize(p), 0.8)
@@ -815,6 +835,8 @@ test_that("ObiwarpParam works", {
 })
 
 test_that("GenericParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     prm <- GenericParam(fun = "mean")
     expect_equal(prm@fun, "mean")
     ## Errors
@@ -823,6 +845,8 @@ test_that("GenericParam works", {
 })
 
 test_that("FillChromPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check getter/setter methods:
     p <- new("FillChromPeaksParam", expandMz = 0.8)
     expect_equal(expandMz(p), 0.8)
@@ -869,6 +893,8 @@ test_that("FillChromPeaksParam works", {
 })
 
 test_that("CalibrantMassParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- new("CalibrantMassParam")
     expect_true(validObject(p))
     p@method <- "other"
@@ -889,6 +915,8 @@ test_that("CalibrantMassParam works", {
 })
 
 test_that("CleanPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- new("CleanPeaksParam")
     expect_true(validObject(p))
     p@maxPeakwidth <- c(1, 4)
@@ -901,6 +929,8 @@ test_that("CleanPeaksParam works", {
 })
 
 test_that("MergeNeighboringPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- new("MergeNeighboringPeaksParam")
     expect_true(validObject(p))
     p@expandRt <- c(1, 4)
@@ -936,6 +966,8 @@ test_that("MergeNeighboringPeaksParam works", {
 })
 
 test_that("ChromPeakAreaParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- ChromPeakAreaParam()
     expect_true(is(res, "ChromPeakAreaParam"))
     res <- ChromPeakAreaParam(mzmin = median)
@@ -943,6 +975,8 @@ test_that("ChromPeakAreaParam works", {
 })
 
 test_that("FilterIntensityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- FilterIntensityParam()
     expect_true(is(res, "FilterIntensityParam"))
     res <- FilterIntensityParam(threshold = 100)

--- a/tests/testthat/test_do_adjustRtime-functions.R
+++ b/tests/testthat/test_do_adjustRtime-functions.R
@@ -1,4 +1,6 @@
 test_that("getPeakGroupsRtMatrix works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     param <- PeakGroupsParam()
     nSamples <- length(fileNames(xod_xg))
     pkGrp <- .getPeakGroupsRtMatrix(
@@ -16,6 +18,8 @@ test_that("getPeakGroupsRtMatrix works", {
 })
 
 test_that("do_adjustRtime_peakGroups works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xsa <- xod_xgr
     xsg <- xod_xg
     misSamp <- 1
@@ -51,6 +55,8 @@ test_that("do_adjustRtime_peakGroups works", {
 })
 
 test_that("applyRtAdjustment works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xs <- faahko
     ## group em.
     ## xsg <- group(xs)
@@ -90,6 +96,8 @@ test_that("applyRtAdjustment works", {
 })
 
 test_that(".get_closest_index works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_equal(.get_closest_index(2, c(1, 3, 5, 7)), 3)
     expect_equal(.get_closest_index(2, c(1, 3, 5, 7), method = "previous"), 1)
     expect_equal(.get_closest_index(2, c(1, 3, 5, 7), method = "closest"), 1)
@@ -123,6 +131,8 @@ test_that(".get_closest_index works", {
 })
 
 test_that(".match_trim_vectors and index works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- .match_trim_vectors(list(1:10, 3:10))
     expect_equal(res, list(3:10, 3:10))
     res <- .match_trim_vectors(list(3:10, 4:15))
@@ -136,6 +146,8 @@ test_that(".match_trim_vectors and index works", {
 })
 
 test_that("adjustRtimeSubset works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     rt_raw <- rtime(xod_xgr, adjusted = FALSE, bySample = TRUE)
     rt_adj <- rtime(xod_xgr, adjusted = TRUE, bySample = TRUE)
 

--- a/tests/testthat/test_do_findChromPeaks-functions.R
+++ b/tests/testthat/test_do_findChromPeaks-functions.R
@@ -1,4 +1,6 @@
 test_that("do_findPeaks_MSW works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     first_file <- filterFile(fticr, file = 1)
     spctr <- spectra(first_file)
     expect_true(length(spctr) == 1)
@@ -14,6 +16,8 @@ test_that("do_findPeaks_MSW works", {
 })
 
 test_that("do_findChromPeaks_centWave works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## We expect that changing a parameter has an influence on the result.
     mzVals <- mz(xod_x)
     intVals <- unlist(intensity(xod_x), use.names = FALSE)
@@ -38,6 +42,8 @@ test_that("do_findChromPeaks_centWave works", {
 })
 
 test_that("do_findChromPeaks_centWaveWithPredIsoROIs works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterFile(od_x, 1)
     mzVals <- mz(tmp)
     intVals <- unlist(intensity(tmp), use.names = FALSE)
@@ -62,6 +68,8 @@ test_that("do_findChromPeaks_centWaveWithPredIsoROIs works", {
 })
 
 test_that("do_findChromPeaks_massifquant works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterFile(od_x, 1)
     mz <- mz(tmp)
     valsPerSpect <- lengths(mz)
@@ -81,6 +89,8 @@ test_that("do_findChromPeaks_massifquant works", {
 })
 
 test_that("do_findChromPeaks_matchedFilter works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterFile(od_x, 1)
     mzVals <- mz(tmp)
     valsPerSpect <- lengths(mzVals)
@@ -138,6 +148,8 @@ test_that("do_findChromPeaks_matchedFilter works", {
 })
 
 test_that("peaksWithMatchedFilter is working", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- filterFile(faahko_od, file = 1)
     od_mf <- findChromPeaks(od, param = MatchedFilterParam())
 
@@ -160,6 +172,8 @@ test_that("peaksWithMatchedFilter is working", {
 })
 
 test_that(".getRtROI works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- filterFile(faahko_od, file = 1)
     expect_error(.getRtROI())
     expect_error(.getRtROI(1:3))
@@ -218,6 +232,8 @@ test_that(".getRtROI works", {
 })
 
 test_that("peaksWithCentWave works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- filterFile(faahko_od, file = 1)
     mzr <- c(272.1, 272.2)
 
@@ -286,6 +302,8 @@ test_that("peaksWithCentWave works", {
 })
 
 test_that(".narrow_rt_boundaries works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     d <- c(0, 0, 1, 2, 1, 3, 4, 6, 4, 3, 2, 0, 1, 0, 2, 0)
 
     ## Full range

--- a/tests/testthat/test_do_groupChromPeaks-functions.R
+++ b/tests/testthat/test_do_groupChromPeaks-functions.R
@@ -1,4 +1,6 @@
 test_that("do_groupChromPeaks_density works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fts <- chromPeaks(xod_xg)
     grps <- rep(1, 3)
     res <- do_groupChromPeaks_density(fts, sampleGroups = grps)
@@ -8,6 +10,8 @@ test_that("do_groupChromPeaks_density works", {
 })
 
 test_that("do_groupPeaks_mzClust works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fts <- chromPeaks(fticr_xod)
     res <- do_groupPeaks_mzClust(peaks = fts,
                                  sampleGroups = c(1, 1))
@@ -26,6 +30,8 @@ test_that("do_groupPeaks_mzClust works", {
 })
 
 test_that("do_groupChromPeaks_nearest works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterFile(xod_xg)
     features <- chromPeaks(tmp)
     sampleGroups <- rep(1, length(fileNames(tmp)))
@@ -40,6 +46,8 @@ test_that("do_groupChromPeaks_nearest works", {
 })
 
 test_that(".group_peaks_density works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     x <- rbind(c(rt = 3.1, mz = 3, index = 1, sample = 1, into = 120),
                c(rt = 3.2, mz = 3, index = 2, sample = 2, into = 130),
                c(rt = 3.15, mz = 3, index = 3, sample = 3, into = 29),

--- a/tests/testthat/test_functions-Chromatogram.R
+++ b/tests/testthat/test_functions-Chromatogram.R
@@ -1,4 +1,6 @@
 test_that(".chrom_merge_neighboring_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ints <- c(0.5, 1, 1, 3, 6, 9, 12, 13, 11, 6, 5, 3, 1, 1, 1.5, 1, 4, 6,
               8, 9, 8, 6, 3, 2, 1.3, 1, 0.7, 0.5, 1, 1, 1, 0.5, 3, 5, 8,
               12, 10, 9, 6, 3, 2, 1, 1, 1)

--- a/tests/testthat/test_functions-OnDiskMSnExp.R
+++ b/tests/testthat/test_functions-OnDiskMSnExp.R
@@ -1,4 +1,6 @@
 test_that(".obiwarp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 
     od <- faahko_od
     xod <- faahko_xod
@@ -48,6 +50,8 @@ test_that(".obiwarp works", {
 })
 
 test_that(".concatenate_OnDiskMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od1 <- filterFile(od_x, 1)
     od2 <- filterFile(od_x, 2:3)
     res <- .concatenate_OnDiskMSnExp(od1, od2)
@@ -77,6 +81,8 @@ test_that(".concatenate_OnDiskMSnExp works", {
 })
 
 test_that(".split_by_file and .split_bu_file2 work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     a <- lapply(seq_along(fileNames(od_x)), filterFile, object = od_x)
     b <- .split_by_file(od_x, subsetFeatureData = FALSE)
     expect_equal(a[[2]][[19]], b[[2]][[19]])
@@ -109,6 +115,8 @@ test_that(".split_by_file and .split_bu_file2 work", {
 })
 
 test_that(".estimate_prec_intensity works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterRt(as(pest_dda, "OnDiskMSnExp"), c(300, 400))
     res <- .estimate_prec_intensity(tmp, method = "previous")
     expect_true(length(res) == length(tmp))
@@ -120,6 +128,8 @@ test_that(".estimate_prec_intensity works", {
 })
 
 test_that("estimatePrecursorIntensity,OnDiskMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterRt(pest_dda, c(300, 400))
     res <- estimatePrecursorIntensity(tmp, BPPARAM = SerialParam())
     expect_true(length(res) == length(tmp))
@@ -129,6 +139,8 @@ test_that("estimatePrecursorIntensity,OnDiskMSnExp works", {
 })
 
 test_that(".OnDiskMSnExp2MsBackendMzR works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     if (requireNamespace("Spectra", quietly = TRUE)) {
         res <- .OnDiskMSnExp2MsBackendMzR(xod_x)
         expect_equal(Spectra::rtime(res), unname(rtime(xod_x)))
@@ -136,6 +148,8 @@ test_that(".OnDiskMSnExp2MsBackendMzR works", {
 })
 
 test_that(".fData2MsBackendMzR works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     if (requireNamespace("Spectra", quietly = TRUE)) {
         res <- .fData2MsBackendMzR(fData(xod_x), fileNames(xod_x))
         expect_true(is(res, "MsBackendMzR"))

--- a/tests/testthat/test_functions-ProcessHistory.R
+++ b/tests/testthat/test_functions-ProcessHistory.R
@@ -1,4 +1,6 @@
 test_that("ProcessHistory constructor and class works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ph <- ProcessHistory()
     expect_true(inherits(ph, "ProcessHistory"))
 
@@ -21,6 +23,8 @@ test_that("ProcessHistory constructor and class works", {
 })
 
 test_that("XProcessHistory works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ph <- XProcessHistory()
     expect_true(is(ph, "XProcessHistory"))
     expect_true(inherits(ph, "ProcessHistory"))
@@ -42,6 +46,8 @@ test_that("XProcessHistory works", {
 })
 
 test_that("GenericProcessHistory works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xs <- list()
     xs <- c(xs, GenericProcessHistory(fun = "mean"))
     xs <- c(xs, GenericProcessHistory(fun = "median"))
@@ -55,6 +61,8 @@ test_that("GenericProcessHistory works", {
 })
 
 test_that(".process_history_subset_samples works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ph <- list(XProcessHistory(CentWaveParam()))
     expect_equal(.process_history_subset_samples(ph), ph)
     ph <- list(XProcessHistory(CentWaveParam(), fileIndex = 1:10))

--- a/tests/testthat/test_functions-XCMSnExp.R
+++ b/tests/testthat/test_functions-XCMSnExp.R
@@ -1,4 +1,6 @@
 test_that("XCMSnExp new works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Basic contructor.
     x <- new("XCMSnExp")
     x@.processHistory <- list("a")
@@ -14,6 +16,8 @@ test_that("XCMSnExp new works", {
 })
 
 test_that("adjustRtimePeakGroups works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pkGrp <- adjustRtimePeakGroups(xod_xg,
                                    param = PeakGroupsParam(minFraction = 1))
     expect_equal(colnames(pkGrp), basename(fileNames(xod_xg)))
@@ -43,6 +47,8 @@ test_that("adjustRtimePeakGroups works", {
 })
 
 test_that("plotAdjustedRtime works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     plotAdjustedRtime(xod_xgr, ylim = c(-20, 40))
     plotAdjustedRtime(xod_xgrg)
     expect_warning(plotAdjustedRtime(xod_x))
@@ -50,6 +56,8 @@ test_that("plotAdjustedRtime works", {
 })
 
 test_that("plotChromPeakDensity works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- c(305.05, 305.15)
     .plotChromPeakDensity(xod_x, mz = mzr)
     plotChromPeakDensity(xod_x, mz = mzr)
@@ -70,6 +78,8 @@ test_that("plotChromPeakDensity works", {
 })
 
 test_that("plotChromPeaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Plot the full range.
     plotChromPeaks(xod_x)
 
@@ -79,6 +89,8 @@ test_that("plotChromPeaks works", {
 })
 
 test_that("plotChromPeakImage works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     plotChromPeakImage(xod_x, binSize = 30, log = FALSE)
     ## Check that it works if no peaks were found in one sample.
     tmp <- xod_x
@@ -91,6 +103,8 @@ test_that("plotChromPeakImage works", {
 })
 
 test_that("applyAdjustedRtime works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(applyAdjustedRtime(faahko_od))
     expect_equal(applyAdjustedRtime(faahko_xod), faahko_xod)
     ## Now really replacing the stuff.
@@ -105,6 +119,8 @@ test_that("applyAdjustedRtime works", {
 })
 
 test_that(".concatenate_XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xod1 <- filterFile(faahko_xod, 1)
     xod2 <- filterFile(faahko_xod, 2)
     xod3 <- filterFile(faahko_xod, 3)
@@ -119,6 +135,8 @@ test_that(".concatenate_XCMSnExp works", {
 })
 
 test_that("filterFeatureDefinitions works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- xod_xgrg
     expect_error(filterFeatureDefinitions("a"))
     expect_error(filterFeatureDefinitions(xod_xgr, 1:3))
@@ -139,6 +157,8 @@ test_that("filterFeatureDefinitions works", {
 })
 
 test_that("featureSummary works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(featureSummary(1:3))
     expect_error(featureSummary(xod_xgrg, group = 1:5))
     expect_error(featureSummary(xod_xgr))
@@ -181,6 +201,8 @@ test_that("featureSummary works", {
 })
 
 test_that("overlappingFeatures works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Errors
     expect_error(overlappingFeatures())
     expect_error(overlappingFeatures(4))
@@ -192,6 +214,8 @@ test_that("overlappingFeatures works", {
 })
 
 test_that("exportMetaboAnalyst works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(exportMetaboAnalyst(xod_x))
     expect_error(exportMetaboAnalyst(4))
     expect_error(exportMetaboAnalyst(xod_xg))
@@ -219,6 +243,8 @@ test_that("exportMetaboAnalyst works", {
 })
 
 test_that("chromPeakSpectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## For now we don't have MS1/MS2 data, so we have to stick to errors etc.
     expect_error(ms2_mspectrum_for_all_peaks(xod_x, method = "other"))
     expect_error(res <- chromPeakSpectra(od_x))
@@ -272,6 +298,8 @@ test_that("chromPeakSpectra works", {
 })
 
 test_that("featureSpectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## For now we don't have MS1/MS2 data, so we have to stick to errors etc.
     expect_error(ms2_mspectrum_for_features(xod_x, method = "other"))
     expect_error(res <- featureSpectra(xod_x))
@@ -296,6 +324,8 @@ test_that("featureSpectra works", {
 })
 
 test_that("featureChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(featureChromatograms(xod_x))
 
     fts <- rownames(featureDefinitions(xod_xgrg))
@@ -367,6 +397,8 @@ test_that("featureChromatograms works", {
 })
 
 test_that("highlightChromPeaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- c(279, 279)
     rtr <- c(2700, 2850)
     chr <- chromatogram(xod_xgrg, mz = mzr, rt = rtr)
@@ -386,6 +418,8 @@ test_that("highlightChromPeaks works", {
 })
 
 test_that(".swath_collect_chrom_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     obj <- dropChromPeaks(pest_swth)
     msf <- new("MsFeatureData")
     ## msf@.xData <- .copy_env(obj@msFeatureData)
@@ -453,6 +487,8 @@ test_that(".swath_collect_chrom_peaks works", {
 })
 
 test_that("findChromPeaksIsolationWindow works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     obj <- filterRt(as(pest_swth, "OnDiskMSnExp"), rt = c(0, 300))
     cwp <- CentWaveParam(snthresh = 5, noise = 100, ppm = 10,
                          peakwidth = c(3, 30), prefilter = c(2, 1000))
@@ -488,6 +524,8 @@ test_that("findChromPeaksIsolationWindow works", {
 })
 
 test_that("reconstructChromPeakSpectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- reconstructChromPeakSpectra(
         pest_swth, peakId = rownames(chromPeaks(pest_swth))[5:6])
     expect_true(length(res) == 2)
@@ -508,6 +546,8 @@ test_that("reconstructChromPeakSpectra works", {
 })
 
 test_that(".plot_XIC works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- c(453, 453.5)
     rtr <- c(2400, 2700)
 
@@ -521,6 +561,8 @@ test_that(".plot_XIC works", {
 })
 
 test_that(".group_overlapping_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzmin <- c(123.3, 123.35, 123.5, 341, 342.1, 343.2, 564, 564.3)
     mzmax <- c(123.4, 123.5, 124, 342, 343, 344, 564.1, 566)
     pks <- cbind(mzmin, mzmax)
@@ -544,6 +586,8 @@ test_that(".group_overlapping_peaks works", {
 })
 
 test_that(".merge_neighboring_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xod_x1 <- filterFile(xod_x, 1L)
     res <- .merge_neighboring_peaks(xod_x1, expandRt = 4)
     expect_true(is.list(res))
@@ -591,6 +635,8 @@ test_that(".merge_neighboring_peaks works", {
 })
 
 test_that(".XCMSnExp2SummarizedExperiment works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(.XCMSnExp2SummarizedExperiment(xod_x), "No correspondence")
 
     res <- .XCMSnExp2SummarizedExperiment(xod_xgrg)
@@ -606,6 +652,8 @@ test_that(".XCMSnExp2SummarizedExperiment works", {
 })
 
 test_that(".features_ms_region works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- .features_ms_region(xod_xgrg, msLevel = 1L)
     expect_equal(nrow(res), nrow(featureDefinitions(xod_xgrg)))
     expect_equal(colnames(res), c("mzmin", "mzmax", "rtmin", "rtmax"))
@@ -617,6 +665,8 @@ test_that(".features_ms_region works", {
 })
 
 test_that(".which_peaks_above_threshold works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xsub <- filterRt(filterFile(xod_x, 1L), rt = c(2500, 3500))
     pks <- chromPeaks(xsub)
     res <- .chrom_peaks_above_threshold(xsub, threshold = 100, nValues = 4)
@@ -630,6 +680,8 @@ test_that(".which_peaks_above_threshold works", {
 })
 
 test_that("manualChromPeaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     cp <- cbind(mzmin = c(453, 301.9, 100),
                 mzmax = c(453.5, 302.1, 102),
                 rtmin = c(2400, 2500, 2460),
@@ -654,6 +706,8 @@ test_that("manualChromPeaks works", {
 })
 
 test_that(".spectra_for_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     if (requireNamespace("Spectra", quietly = TRUE)) {
         res_all <- .spectra_for_peaks(pest_dda, method = "all")
         expect_true(length(res_all) == nrow(chromPeaks(pest_dda)))
@@ -677,6 +731,8 @@ test_that(".spectra_for_peaks works", {
 })
 
 test_that(".spectra_for_features works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     if (requireNamespace("Spectra", quietly = TRUE)) {
         res <- .spectra_for_features(xod_xgrg, method = "closest_rt",
                                      msLevel = 2L)
@@ -715,6 +771,8 @@ test_that(".spectra_for_features works", {
 })
 
 test_that("manualFeatures works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     idx <- list(1:4, c(4, "a"))
     expect_error(manualFeatures(od_x, idx), "XCMSnExp")
     ## Add features to an XCMSnExp without features.

--- a/tests/testthat/test_functions-XChromatogram.R
+++ b/tests/testthat/test_functions-XChromatogram.R
@@ -1,4 +1,6 @@
 test_that(".validXChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xc <- new("XChromatogram")
     expect_true(.validXChromatogram(xc))
     xc@chromPeaks <- matrix(1:10, ncol = 5)
@@ -23,6 +25,8 @@ test_that(".validXChromatogram works", {
 })
 
 test_that("XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xc <- XChromatogram(rtime = 1:10, intensity = 1:10)
     expect_true(nrow(xc@chromPeaks) == 0)
     expect_true(nrow(xc@chromPeakData) == 0)
@@ -54,6 +58,8 @@ test_that("XChromatogram works", {
 })
 
 test_that(".add_chromatogram_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xc <- XChromatogram(rtime = 1:10, intensity = c(2, 5, 12, 32, 38, 21, 13,
                                                     5, 5, 9))
     plot(xc)
@@ -69,6 +75,8 @@ test_that(".add_chromatogram_peaks works", {
 })
 
 test_that(".xchrom_merge_neighboring_peaks and refineChromPeaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- filterFile(xod_x, 1)
     mzr <- 305.1 + c(-0.01, 0.01)
     chr <- chromatogram(tmp, mz = mzr)
@@ -83,6 +91,8 @@ test_that(".xchrom_merge_neighboring_peaks and refineChromPeaks works", {
 })
 
 test_that(".filter_chrom_peaks_keep_top works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- chromatogram(xod_x, mz = rbind(305.1 + c(-0.01, 0.01),
                                            462.2 + c(-0.04, 0.04)))
     a <- chrs[1, 1]

--- a/tests/testthat/test_functions-XChromatograms.R
+++ b/tests/testthat/test_functions-XChromatograms.R
@@ -1,4 +1,6 @@
 test_that("XChromatograms, as, validator, hasChromPeaks work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr1 <- Chromatogram(rtime = 1:8,
                          intensity = c(3, 24.2, 343, 32, 3.3, 5, 2, 9))
     chr2 <- Chromatogram(rtime = 1:4, intensity = c(45, 3, 34, 2))
@@ -61,6 +63,8 @@ test_that("XChromatograms, as, validator, hasChromPeaks work", {
 })
 
 test_that(".subset_chrom_peaks_xchromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Matrix is:    with elements
     ## A B C D       2 1 3 1
     ## E F G H       1 4 0 2
@@ -119,6 +123,8 @@ test_that(".subset_chrom_peaks_xchromatograms works", {
 })
 
 test_that(".subset_features_on_chrom_peaks works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- as(od_chrs, "XChromatograms")
     chrs <- findChromPeaks(chrs, param = CentWaveParam())
     prm <- PeakDensityParam(sampleGroups = c(1, 1, 1))
@@ -156,6 +162,8 @@ test_that(".subset_features_on_chrom_peaks works", {
 })
 
 test_that(".plot_chrom_peak_density works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- as(od_chrs, "XChromatograms")
     chrs <- findChromPeaks(chrs, param = CentWaveParam())
 

--- a/tests/testthat/test_functions-binning.R
+++ b/tests/testthat/test_functions-binning.R
@@ -1,4 +1,6 @@
 test_that("binYonX NA handling works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## NA values in y should be ignored internally.
     X <- 1:10
     Y <- X
@@ -21,6 +23,8 @@ test_that("binYonX NA handling works", {
 })
 
 test_that("binYonX max works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     X <- 1:10
     Y <- 1:10
     breakMidPoint <- function(x) {
@@ -201,6 +205,8 @@ test_that("binYonX max works", {
 
 ## Test binning using min
 test_that("binYonX min works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     X <- 1:10
     breakMidPoint <- function(x) {
         return((x[-1L] + x[-length(x)])/2)
@@ -257,6 +263,8 @@ test_that("binYonX min works", {
 
 ## Test binning using sum
 test_that("binYonX sum works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     X <- 1:10
     breakMidPoint <- function(x) {
         return((x[-1L] + x[-length(x)])/2)
@@ -312,6 +320,8 @@ test_that("binYonX sum works", {
 
 ## Test binning using mean
 test_that("binYonX mean works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     X <- 1:10
     breakMidPoint <- function(x) {
         return((x[-1L] + x[-length(x)])/2)
@@ -342,6 +352,8 @@ test_that("binYonX mean works", {
 })
 
 test_that("breaks defining functions work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Test generation of breaks for binning.
     ## o nBins
     res <- breaks_on_nBins(1, 10, 4)
@@ -393,6 +405,8 @@ test_that("breaks defining functions work", {
 })
 
 test_that("binYonX with imputation_lin works",  {
+    skip_on_os(os = "windows", arch = "i386")
+
     X <- 1:11
     brks <- breaks_on_nBins(1, 11, 5L)
     Y <- c(1, NA, NA, NA, 5, 6, NA, NA, 9, 10, 11)
@@ -463,6 +477,8 @@ test_that("binYonX with imputation_lin works",  {
 })
 
 test_that("binYonX with imputation_linbin works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     doPlot <- FALSE
     ## Construct example:
     ## We're using the same test than we did for profBinLinBase.
@@ -559,6 +575,8 @@ test_that("binYonX with imputation_linbin works", {
 })
 
 ## test_that("testIntegerInput and testDoubleInput works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 
 ##     xcms:::testIntegerInput(4)
 ##     xcms:::testIntegerInput(c(4, 5))
@@ -569,6 +587,8 @@ test_that("binYonX with imputation_linbin works", {
 ## })
 
 test_that("binYonX on subsets works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Simple test without actually needing subsets.
     X <- 1:11
     Y <- 1:11

--- a/tests/testthat/test_functions-imputation.R
+++ b/tests/testthat/test_functions-imputation.R
@@ -1,4 +1,6 @@
 test_that("imputeRowMin works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mat <- cbind(c(4, 2, 4, NA, NA), c(NA, NA, NA, NA, NA), c(4, NA, 6, 3, 9),
                  c(6, 3, NA, 6, NA))
     mat_imp <- imputeRowMin(mat)
@@ -9,6 +11,8 @@ test_that("imputeRowMin works", {
 })
 
 test_that("imputeRowMinRand works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     mat <- cbind(c(4, 2, 4, NA, NA), c(NA, NA, NA, NA, NA), c(4, NA, 6, 3, 9),
                  c(6, 3, NA, 6, NA))

--- a/tests/testthat/test_functions-normalization.R
+++ b/tests/testthat/test_functions-normalization.R
@@ -1,4 +1,6 @@
 test_that("fitModel works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     vals <- featureValues(xod_xgrg)
     dat <- data.frame(injection_idx = 1:length(fileNames(xod_xgrg)))
     fits <- rowFitModel(formula = y ~ injection_idx, y = vals,
@@ -15,6 +17,8 @@ test_that("fitModel works", {
 
 
 test_that("model adjustment with batch works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Here we test that linear model based adjustment with a batch is
     ## working.
     y <- c(2, 3, 2.7, 3.5, 3.8, 4.6, 5.9, 8, 4, 5.1, 5.6, 6.8, 7.1, 8.1, 8.9,
@@ -55,6 +59,8 @@ test_that("model adjustment with batch works", {
 })
 
 test_that("fitModel, rowFitModel works on matrix and vector", {
+    skip_on_os(os = "windows", arch = "i386")
+
     y <- c(2, 3, 2.7, 3.5, 3.8, 4.6, 5.9, 8, 4, 5.1, 5.6, 6.8, 7.1)
     inj_idx <- 1:length(y)
     dta <- data.frame(inj_idx = inj_idx)
@@ -125,6 +131,8 @@ test_that("fitModel, rowFitModel works on matrix and vector", {
 })
 
 test_that("applyModelAdjustment works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     y <- c(2, 3, 2.7, 3.5, 3.8, 4.6, 5.9, 8, 4, 5.1, 5.6, 6.8, 7.1)
     inj_idx <- 1:length(y)
     btch <- c(rep("a", 8), rep("b", 5))
@@ -186,6 +194,8 @@ test_that("applyModelAdjustment works", {
 })
 
 test_that("replaceNaOnEnds works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     x <- c(NA, 3, 4, 6, 4, 2, NA, 3, NA, 4, 5, 6, NA)
     expect_equal(replaceNaOnEnds(x), c(3, 3, 4, 6, 4, 2, NA, 3, NA, 4, 5, 6, 6))
 

--- a/tests/testthat/test_functions-utils.R
+++ b/tests/testthat/test_functions-utils.R
@@ -1,4 +1,6 @@
 test_that(".createProfileMatrix works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xr <- filterFile(faahko_od, 1)
     mz <- mz(xr)
     int <- unlist(intensity(xr), use.names = FALSE)
@@ -45,11 +47,15 @@ test_that(".createProfileMatrix works", {
 })
 
 test_that("plotMsData works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     msd <- extractMsData(faahko_od, mz = c(334.9, 335.1), rt = c(2700, 2900))
     plotMsData(msd[[1]])
 })
 
 test_that(".featureIDs works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- .featureIDs(200)
     expect_equal(length(res), 200)
     expect_true(length(unique(res)) == 200)
@@ -58,6 +64,8 @@ test_that(".featureIDs works", {
 })
 
 test_that("rla, rowRla work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     x <- c(3, 4, 5, 1, 2, 3, 7, 8, 9)
     grp <- c(1, 1, 1, 2, 2, 2, 3, 3, 3)
     res <- rla(x, grp)
@@ -79,6 +87,8 @@ test_that("rla, rowRla work", {
 })
 
 test_that(".rect_overlap works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xl <- c(1, 3, 1.5, 4, 4, 5.5, 7, 6)
     xr <- c(2, 4, 3.5, 5, 5, 6.5, 8, 7.5)
     yb <- c(1, 2, 3.5, 4.5, 7, 8, 9.5, 10.5)
@@ -173,6 +183,8 @@ test_that(".rect_overlap works", {
 })
 
 test_that(".insertColumn works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mat <- matrix(1:100, ncol = 5)
     expect_equal(.insertColumn(mat), mat)
 
@@ -196,6 +208,8 @@ test_that(".insertColumn works", {
 })
 
 test_that(".ppm_range works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- .ppm_range(100)
     expect_equal(res[1], 100)
     expect_equal(res[2], 100)
@@ -205,6 +219,8 @@ test_that(".ppm_range works", {
 })
 
 test_that(".update_feature_definitions works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     cps <- matrix(nrow = 22, ncol = 3)
     rownames(cps) <- 1:22
     fts <- DataFrame(a = letters[1:6])
@@ -234,6 +250,8 @@ test_that(".update_feature_definitions works", {
 })
 
 ## test_that(".chrom_peak_id works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 ##     res <- .chrom_peak_id(matrix(nrow = 0, ncol = 5))
 ##     expect_equal(res, character())
 ##     cpks <- rbind(c(3, 2, 4, 12, 13),
@@ -249,6 +267,8 @@ test_that(".update_feature_definitions works", {
 ## })
 
 test_that(".rbind_fill works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## matrix
     a <- matrix(1:9, nrow = 3, ncol = 3)
     colnames(a) <- c("a", "b", "c")
@@ -275,6 +295,8 @@ test_that(".rbind_fill works", {
 })
 
 test_that(".reduce works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     a <- c(1.23, 1.431, 2.43, 5.44, 6)
     b <- c(1.33, 2.43, 5, 6, 7)
     res <- .reduce(a, b)
@@ -317,6 +339,8 @@ test_that(".reduce works", {
 })
 
 test_that("groupOverlaps works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     x <- c(12.2, 13, 5)
     y <- c(16, 15, 6)
     res <- groupOverlaps(x, y)
@@ -328,12 +352,16 @@ test_that("groupOverlaps works", {
 })
 
 test_that(".require_spectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     if (requireNamespace("Spectra", quietly = TRUE))
         expect_true(.require_spectra())
     else expect_error("installed.")
 })
 
 test_that(".i2index works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ids <- c("a", "b", "c", "d")
     res <- .i2index(c("c", "d"), ids)
     expect_equal(res, c(3L, 4L))

--- a/tests/testthat/test_functions-xcmsSwath.R
+++ b/tests/testthat/test_functions-xcmsSwath.R
@@ -1,4 +1,6 @@
 test_that(".which_mz_in_range works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mz <- 3.4
     lowerMz <- c(1, 3, 8, 12)
     upperMz <- c(3, 7, 11, 15)
@@ -9,6 +11,8 @@ test_that(".which_mz_in_range works", {
 })
 
 test_that(".which_chrom_peak_overlap_rt works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pks <- cbind(rtmin = c(1, 2, 3, 4, 5), rtmax = c(2, 3, 4, 5, 6))
     res <- .which_chrom_peak_overlap_rt(c(rtmin = 1.1, rtmax = 2.2), pks)
     expect_equal(res, c(1L, 2L))
@@ -17,6 +21,8 @@ test_that(".which_chrom_peak_overlap_rt works", {
 })
 
 test_that(".which_chrom_peak_diff_rt works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pks <- cbind(rt = c(1, 2, 3, 4, 5), rtmax = c(2, 3, 4, 5, 6))
     res <- .which_chrom_peak_diff_rt(c(rt = 1.1), pks, diffRt = 2)
     expect_equal(res, c(1L, 2L, 3L))
@@ -25,6 +31,8 @@ test_that(".which_chrom_peak_diff_rt works", {
 })
 
 test_that(".reconstruct_ms2_for_chrom_peak works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Fluopicolide, exact mass = 381.965430576, [M+H]+ = 382.972706
     pk <- chromPeaks(pest_swth, mz = 382.972706, ppm = 10)
     res <- .reconstruct_ms2_for_chrom_peak(pk, pest_swth, fromFile = 7L,
@@ -62,6 +70,8 @@ test_that(".reconstruct_ms2_for_chrom_peak works", {
 })
 
 test_that(".reconstruct_ms2_for_peaks_file works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## No MS2 level peaks: expect empty.
     tmp <- filterRt(filterFile(xod_x, 1), rt = c(2500, 3000))
     res <- xcms:::.reconstruct_ms2_for_peaks_file(tmp)
@@ -116,6 +126,8 @@ test_that(".reconstruct_ms2_for_peaks_file works", {
 })
 
 test_that(".data2spectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## empty one, no mz, no intensity, just rt fromFile etc.
     res <- .data2spectra(rt = 3.2, polarity = 1L, precursorMz = 12.3,
                          precursorIntensity = 1234, return.type = "MSpectra")

--- a/tests/testthat/test_matchpeaks.R
+++ b/tests/testthat/test_matchpeaks.R
@@ -1,4 +1,6 @@
 test_that("matchpeaks doesn't fail", {
+    skip_on_os(os = "windows", arch = "i386")
+
     faahko_file <- system.file('cdf/KO/ko15.CDF', package = "faahKO")
 
     faahko_xs <- xcmsSet(faahko_file, profparam = list(step = 0),

--- a/tests/testthat/test_methods-Chromatogram.R
+++ b/tests/testthat/test_methods-Chromatogram.R
@@ -1,4 +1,6 @@
 test_that("findChromPeaks,Chromatogram,MatchedFilterParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- filterFile(faahko_od, file = 1)
     mzr <- c(272.1, 272.2)
 
@@ -16,6 +18,8 @@ test_that("findChromPeaks,Chromatogram,MatchedFilterParam works", {
 })
 
 test_that("findChromPeaks,Chromatogram,CentWaveParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- filterFile(faahko_od, file = 1)
     mzr <- c(272.1, 272.2)
 
@@ -41,6 +45,8 @@ test_that("findChromPeaks,Chromatogram,CentWaveParam works", {
 })
 
 test_that("removeIntensity,Chromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr <- Chromatogram(rtime = c(1, 2, 3, 4, 5, 6, 7),
                         intensity = c(NA_real_, 13, 16, 22, 34, 15, 6))
     res <- removeIntensity(chr)

--- a/tests/testthat/test_methods-MChromatograms.R
+++ b/tests/testthat/test_methods-MChromatograms.R
@@ -1,4 +1,6 @@
 test_that("findChromPeaks,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     chrs <- chromatogram(od_x, mz = mzr)
     res <- findChromPeaks(chrs, param = CentWaveParam())
@@ -21,6 +23,8 @@ test_that("findChromPeaks,MChromatograms works", {
 })
 
 test_that("correlate,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -46,6 +50,8 @@ test_that("correlate,MChromatograms works", {
 })
 
 test_that("removeIntensity,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -72,6 +78,8 @@ test_that("removeIntensity,MChromatograms works", {
 })
 
 test_that("filterColumnsIntensityAbove,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -105,6 +113,8 @@ test_that("filterColumnsIntensityAbove,MChromatograms works", {
 })
 
 test_that("filterChromatogramsKeepTop,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -147,6 +157,8 @@ test_that("filterChromatogramsKeepTop,MChromatograms works", {
 })
 
 test_that("normalize,MChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -167,6 +179,8 @@ test_that("normalize,MChromatograms works", {
 })
 
 test_that(".plot_xchromatograms_overlay works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -182,6 +196,8 @@ test_that(".plot_xchromatograms_overlay works", {
 })
 
 test_that("plotChromatogramsOverlay,MChromatograms,XChromatograms work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     data(xdata)
     dirname(xdata) <- c(rep(system.file("cdf", "KO", package = "faahKO"), 4),
                         rep(system.file("cdf", "WT", package = "faahKO"), 4))

--- a/tests/testthat/test_methods-OnDiskMSnExp.R
+++ b/tests/testthat/test_methods-OnDiskMSnExp.R
@@ -1,4 +1,6 @@
 test_that("profMat,OnDiskMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Get it from all 3 files in one go.
     res <- profMat(filterRt(faahko_od, c(2500, 3000)), step = 2)
     res_2 <- profMat(filterRt(faahko_xod, c(2500, 3000)), step = 2)
@@ -11,6 +13,8 @@ test_that("profMat,OnDiskMSnExp works", {
 })
 
 test_that("findChromPeaks,OnDiskMSnExp,CentWaveParam variants", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Reproduce with msdata files:
     fl <- system.file("microtofq/MM14.mzML", package = "msdata")
     raw <- readMSData(fl, mode = "onDisk")
@@ -88,6 +92,8 @@ test_that("findChromPeaks,OnDiskMSnExp,CentWaveParam variants", {
 })
 
 test_that("findChromPeaks,OnDiskMSnExp,CentWaveParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     onDisk <- filterFile(faahko_od, file = 1)
     ppm <- 40
     snthresh <- 40
@@ -108,6 +114,8 @@ test_that("findChromPeaks,OnDiskMSnExp,CentWaveParam works", {
 })
 
 test_that("findChromPeaks,OnDiskMSnExp,CentWavePredIsoParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## OnDiskMSnExp
     onDisk <- filterFile(faahko_od, file = 1)
     cwp <- CentWavePredIsoParam(snthresh = 20, noise = 2500,
@@ -123,6 +131,8 @@ test_that("findChromPeaks,OnDiskMSnExp,CentWavePredIsoParam works", {
 })
 
 test_that("findChromPeaks,OnDiskMSnExp,MassifquantParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     onDisk <- filterFile(microtofq_od, 1)
     res_o <- findChromPeaks(onDisk, param = MassifquantParam(prefilter = c(5, 5000)))
     expect_true(hasChromPeaks(res_o))
@@ -132,6 +142,8 @@ test_that("findChromPeaks,OnDiskMSnExp,MassifquantParam works", {
 })
 
 test_that("findChromPeaks,OnDiskMSnExp,MatchedFilterParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mfp <- MatchedFilterParam(binSize = 20, impute = "lin")
     onDisk <- filterFile(faahko_od, file = 1)
     res_o <- findChromPeaks(onDisk, param = mfp)
@@ -142,6 +154,8 @@ test_that("findChromPeaks,OnDiskMSnExp,MatchedFilterParam works", {
 })
 
 test_that("isolationWindowTargetMz,OnDiskMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- isolationWindowTargetMz(xod_x)
     expect_true(all(is.na(res)))
     expect_true(length(res) == length(xod_x))

--- a/tests/testthat/test_methods-XCMSnExp.R
+++ b/tests/testthat/test_methods-XCMSnExp.R
@@ -1,4 +1,6 @@
 test_that("XCMSnExp, XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     rts <- rtime(faahko_od)
     rts_2 <- rtime(od_x)
     expect_equal(rts, rts_2)
@@ -13,6 +15,8 @@ test_that("XCMSnExp, XCMSnExp works", {
 })
 
 test_that("mz,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp_od <- filterRt(faahko_od, rt = c(3500, 3800))
     tmp_xod <- filterRt(xod_x, rt = c(3500, 3800))
     mzs <- mz(tmp_od)
@@ -23,6 +27,8 @@ test_that("mz,XCMSnExp works", {
 })
 
 test_that("intensity,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp_od <- filterRt(faahko_od, rt = c(3500, 3800))
     tmp_xod <- filterRt(xod_x, rt = c(3500, 3800))
     ints <- intensity(tmp_od)
@@ -35,6 +41,8 @@ test_that("intensity,XCMSnExp works", {
 })
 
 test_that("spectra,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## xod_x
     tmp <- filterRt(xod_x, rt = c(2700, 2900))
     res <- spectra(tmp)
@@ -68,6 +76,8 @@ test_that("spectra,XCMSnExp works", {
 })
 
 test_that("XCMSnExp accessors work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Filling with data...
     xod <- as(faahko_od, "XCMSnExp")
     ## peaks
@@ -207,6 +217,8 @@ test_that("XCMSnExp accessors work", {
 })
 
 test_that("findChromPeaks,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Call findChromPeaks on an XCMSnExp
     tmp <- findChromPeaks(filterFile(xod_x, 1),
                           param = CentWaveParam(noise = 10000,
@@ -252,6 +264,8 @@ test_that("findChromPeaks,XCMSnExp works", {
 })
 
 test_that("processHistory,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ph <- ProcessHistory(fileIndex. = 2, info. = "For file 2")
     ph_2 <- ProcessHistory(fileIndex. = 1:2, info. = "For files 1 to 2")
     xod <- as(od_x, "XCMSnExp")
@@ -270,6 +284,8 @@ test_that("processHistory,XCMSnExp works", {
 })
 
 test_that("dropChromPeaks,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## 1) dropDetectedFeatures: delete all process history steps and all data.
     res <- dropChromPeaks(xod_x)
     expect_true(!hasChromPeaks(res))
@@ -319,6 +335,8 @@ test_that("dropChromPeaks,XCMSnExp works", {
 })
 
 test_that("dropFeatureDefinitions,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## 2) dropFeatureDefinitions:
     ##    a) drop the feature groups and the latest related process history
     ##    b) if retention time correction was performed AFTER the latest feature
@@ -339,6 +357,8 @@ test_that("dropFeatureDefinitions,XCMSnExp works", {
 })
 
 test_that("dropAdjustedRtime,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## 3) dropAdjustedRtime:
     ##    a) drop the retention time adjustment and related process histories
     ##    b) if grouping has been performed AFTER retention time correction,
@@ -371,6 +391,8 @@ test_that("dropAdjustedRtime,XCMSnExp works", {
 })
 
 test_that("XCMSnExp inherited methods work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## [
     tmp_1 <- faahko_od[1:10]
     tmp_2 <- xod_x[1:10]
@@ -484,6 +506,8 @@ test_that("XCMSnExp inherited methods work", {
 })
 
 test_that("filterFile,XCMSnExp and .filter_file_XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## filterFile
     tmp <- filterFile(xod_x, file = 2)
     expect_error(tmp@msFeatureData$bla <- 3)
@@ -630,6 +654,8 @@ test_that("filterFile,XCMSnExp and .filter_file_XCMSnExp works", {
 })
 
 test_that("filterMz,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## subset on xod_x
     res <- filterMz(xod_x, mz = c(300, 400))
     expect_true(length(res[[1]]) == 1)
@@ -713,6 +739,8 @@ test_that("filterMz,XCMSnExp works", {
 })
 
 test_that("filterRt,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## xod_x
     res <- filterRt(xod_x, rt = c(2700, 2900))
     ## Check if the object is OK:
@@ -874,6 +902,8 @@ test_that("filterRt,XCMSnExp works", {
 
 ## Test the coercion method.
 test_that("as,XCMSnExp,xcmsSet works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od_x <- faahko_xod
     res <- .XCMSnExp2xcmsSet(od_x)
     res <- as(od_x, "xcmsSet")
@@ -938,6 +968,8 @@ test_that("as,XCMSnExp,xcmsSet works", {
 })
 
 test_that("chromatogram,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Have: od_x: OnDiskMSNnExp
     ## xod_x: XCMSnExp, with detected chromPeaks.
     ## xod_xg: with feature groups.
@@ -1099,6 +1131,8 @@ test_that("chromatogram,XCMSnExp works", {
 })
 
 test_that("signal integration is correct", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Testing the signal integration of peaks.
     ## For centWave
     tmp <- xod_xgrg
@@ -1158,6 +1192,8 @@ test_that("signal integration is correct", {
 })
 
 test_that("featureValues,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fdp <- PeakDensityParam(sampleGroups = rep(1, 3))
     od_x <- groupChromPeaks(faahko_xod, param = fdp)
     fvs <- featureValues(od_x, value = "into")
@@ -1252,12 +1288,16 @@ test_that("featureValues,XCMSnExp works", {
 })
 
 test_that("peakIndex,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pkI <- .peakIndex(xod_xg)
     expect_equal(names(pkI), rownames(featureDefinitions(xod_xg)))
     expect_equal(unname(pkI), featureDefinitions(xod_xg)$peakidx)
 })
 
 test_that("MS1 MS2 data works on XCMSnExp", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## That's to test stuff for issues #208 and related (also issue #214).
     ## Set every other spectra in the original files to MS2.
 
@@ -1364,6 +1404,8 @@ test_that("MS1 MS2 data works on XCMSnExp", {
 })
 
 test_that("extractMsData,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## All the data
     ## all <- extractMsData(od_x)
     ## expect_equal(length(all), length(fileNames(od_x)))
@@ -1432,6 +1474,8 @@ test_that("extractMsData,XCMSnExp works", {
 })
 
 test_that("spectrapply and spectra,XCMSnExp work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## With adjusted retention time
     tmp <- filterFile(xod_r, file = 3, keepAdjustedRtime = TRUE)
     expect_true(hasAdjustedRtime(tmp))
@@ -1454,6 +1498,8 @@ test_that("spectrapply and spectra,XCMSnExp work", {
 })
 
 test_that("processHistory,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     type_peak_det <- .PROCSTEP.PEAK.DETECTION
     type_align <- .PROCSTEP.RTIME.CORRECTION
     type_corr <- .PROCSTEP.PEAK.GROUPING
@@ -1469,6 +1515,8 @@ test_that("processHistory,XCMSnExp works", {
 })
 
 test_that("split,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xod <- as(faahko_od, "XCMSnExp")
     tmp <- split(xod_xgr, f = fromFile(xod_xgr))
     ## Split by file.
@@ -1496,11 +1544,15 @@ test_that("split,XCMSnExp works", {
 })
 
 test_that("groupnames,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     gn <- groupnames(xod_xgrg)
     expect_error(groupnames(xod_x))
 })
 
 test_that("calibrate,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     do_plot <- FALSE
     tmp <- filterFile(faahko_xod, file = 1)
 
@@ -1567,6 +1619,8 @@ test_that("calibrate,XCMSnExp works", {
 })
 
 test_that("adjustRtime,peakGroups works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xod <- faahko_xod
     xodg <- groupChromPeaks(xod,
                             param = PeakDensityParam(sampleGroups = rep(1, 3)))
@@ -1668,6 +1722,8 @@ test_that("adjustRtime,peakGroups works", {
 })
 
 test_that("findChromPeaks,MSWParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     od <- microtofq_od
     ## Restrict to first spectrum
     od1 <- od[1]
@@ -1710,6 +1766,8 @@ test_that("findChromPeaks,MSWParam works", {
 })
 
 test_that("featureValues,XCMSnExp works as with groupval", {
+    skip_on_os(os = "windows", arch = "i386")
+
     fval <- featureValues(xod_xg)
     expect_true(nrow(fval) == nrow(featureDefinitions(xod_xg)))
     expect_true(ncol(fval) == length(fileNames(xod_xg)))
@@ -1721,6 +1779,8 @@ test_that("featureValues,XCMSnExp works as with groupval", {
 })
 
 test_that("groupChromPeaks,XCMSnExp,PeakDensityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Check error if no features were found. issue #273
     pdp <- PeakDensityParam(sampleGroups = rep(1, 3), minSamples = 30)
     expect_warning(groupChromPeaks(faahko_xod, param = pdp), "Unable to group any chromatographic peaks.")
@@ -1764,6 +1824,8 @@ test_that("groupChromPeaks,XCMSnExp,PeakDensityParam works", {
 })
 
 test_that("groupPeaks,XCMSnExp,MzClustParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- MzClustParam(sampleGroups = rep(1, length(fileNames(fticr_xod))))
     fticr_xod2 <- groupChromPeaks(fticr_xod, param = p)
     expect_true(hasFeatures(fticr_xod2))
@@ -1785,6 +1847,8 @@ test_that("groupPeaks,XCMSnExp,MzClustParam works", {
 })
 
 test_that("groupChromPeaks,XCMSnExp,NearestPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- NearestPeaksParam(sampleGroups = rep(1, 3))
     res <- groupChromPeaks(faahko_xod, param = p)
     expect_true(hasFeatures(res))
@@ -1818,6 +1882,8 @@ test_that("groupChromPeaks,XCMSnExp,NearestPeaksParam works", {
 })
 
 test_that("fillChromPeaks,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## No adjusted retention times
     expect_true(!.hasFilledPeaks(xod_xg))
     expect_false(hasFilledChromPeaks(xod_xg))
@@ -1977,6 +2043,8 @@ test_that("fillChromPeaks,XCMSnExp works", {
 })
 
 test_that("fillChromPeaks,XCMSnExp works with only MS2 data", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- xod_xgrg
     fData(tmp)[fromFile(tmp) == 2, "msLevel"] <- 2L
     res <- fillChromPeaks(tmp, FillChromPeaksParam(fixedRt = 2))
@@ -1988,11 +2056,15 @@ test_that("fillChromPeaks,XCMSnExp works with only MS2 data", {
 })
 
 test_that("fillChomPeaks,ChromPeakAreaParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- fillChromPeaks(xod_xgrg, ChromPeakAreaParam())
     expect_true(hasFilledChromPeaks(res))
 })
 
 test_that("fillChromPeaks,XCMSnExp with MSW works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     p <- MzClustParam()
     fticr_xodg <- groupChromPeaks(fticr_xod, param = p)
     expect_error(res <- fillChromPeaks(fticr_xod))
@@ -2033,6 +2105,8 @@ test_that("fillChromPeaks,XCMSnExp with MSW works", {
 })
 
 test_that("fillChromPeaks,XCMSnExp with matchedFilter works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- findChromPeaks(faahko_od, param = MatchedFilterParam())
     sg <- rep(1, length(fileNames(tmp)))
     tmp <- groupChromPeaks(tmp, param = PeakDensityParam(sampleGroups = sg))
@@ -2084,6 +2158,8 @@ test_that("fillChromPeaks,XCMSnExp with matchedFilter works", {
 })
 
 test_that("writeMSData,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## Write adjusted retention times
     tmp_path <- tempdir()
     nfls <- paste0(tmp_path, "/",
@@ -2095,6 +2171,8 @@ test_that("writeMSData,XCMSnExp works", {
 })
 
 test_that("adjustRtime,XCMSnExp,Obiwarp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     prm <- ObiwarpParam(centerSample = 3, subset = c(1, 2), binSize = 10)
     expect_error(adjustRtime(xod_x, param = prm))
     prm <- ObiwarpParam(centerSample = 2, subset = c(1, 2), binSize = 10)
@@ -2113,6 +2191,8 @@ test_that("adjustRtime,XCMSnExp,Obiwarp works", {
 })
 
 test_that("dropFilledChromPeaks,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     xod_tmp <- groupChromPeaks(
         xod_xgr, param = PeakDensityParam(sampleGroups = rep(1, 3),
                                           minFraction = 0.25))
@@ -2123,6 +2203,8 @@ test_that("dropFilledChromPeaks,XCMSnExp works", {
 })
 
 test_that("updateObject,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- faahko_xod
     en <- new("MsFeatureData")
     en@.xData <- .copy_env(tmp@msFeatureData@.xData)
@@ -2134,6 +2216,8 @@ test_that("updateObject,XCMSnExp works", {
 })
 
 test_that("filterMsLevel works with MS>1", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ms2 <- filterRt(as(pest_dda, "OnDiskMSnExp"), rt = c(200, 600))
     res <- findChromPeaks(ms2, param = CentWaveParam(
                                    prefilter = c(3, 1000)),
@@ -2151,6 +2235,8 @@ test_that("filterMsLevel works with MS>1", {
 })
 
 test_that("chromPeakData,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     tmp <- xod_x
     expect_error(chromPeakData(tmp) <- 5, "'chromPeakData' is supposed")
     chromPeakData(tmp)$other_column <- "b"
@@ -2190,6 +2276,8 @@ test_that("chromPeakData,XCMSnExp works", {
 })
 
 test_that("plot,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- c(301.9, 302.1)
     rtr <- c(2500, 2650)
     tmp <- filterMz(filterRt(xod_x, rtr), mzr)
@@ -2201,6 +2289,8 @@ test_that("plot,XCMSnExp works", {
 })
 
 test_that("refineChromPeaks,CleanPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     rtw <- chromPeaks(xod_x)[, "rtmax"] - chromPeaks(xod_x)[, "rtmin"]
     res <- refineChromPeaks(xod_x, param = CleanPeaksParam(20))
     rtw2 <- chromPeaks(res)[, "rtmax"] - chromPeaks(res)[, "rtmin"]
@@ -2243,6 +2333,8 @@ test_that("refineChromPeaks,CleanPeaksParam works", {
 })
 
 test_that("refineChromPeaks,MergeNeighboringPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     prm <- MergeNeighboringPeaksParam(expandRt = 4)
     res <- refineChromPeaks(xod_xgr, param = prm)
     expect_true(hasAdjustedRtime(res))
@@ -2285,6 +2377,8 @@ test_that("refineChromPeaks,MergeNeighboringPeaksParam works", {
 })
 
 test_that("refineChromPeaks,FilterIntensityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pks <- chromPeaks(xod_x)
     prm <- FilterIntensityParam(nValues = 1, threshold = 50000)
     res <- refineChromPeaks(xod_x, param = prm, msLevel = 2L)
@@ -2312,6 +2406,8 @@ test_that("refineChromPeaks,FilterIntensityParam works", {
 })
 
 test_that("filterChromPeaks,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- filterChromPeaks(xod_x, keep = c(5, 23, 3))
     expect_true(nrow(chromPeaks(res)) == 3)
     expect_equal(chromPeaks(res), chromPeaks(xod_x)[c(3, 5, 23), ])

--- a/tests/testthat/test_methods-XChromatogram.R
+++ b/tests/testthat/test_methods-XChromatogram.R
@@ -1,8 +1,12 @@
 test_that("show,XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     show(XChromatogram())
 })
 
 test_that("chromPeaks and chromPeakData for XChromatogram work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr <- Chromatogram(rtime = 1:10,
                         intensity = c(4, 12, 18, 24, 23, 18, 15, 3, 2, 5))
     xchr <- as(chr, "XChromatogram")
@@ -54,6 +58,8 @@ test_that("chromPeaks and chromPeakData for XChromatogram work", {
 })
 
 test_that("plot,XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr <- Chromatogram(rtime = 1:10,
                         intensity = c(4, 12, 18, 24, 23, 18, 15, 3, 2, 5))
     xchr <- as(chr, "XChromatogram")
@@ -81,6 +87,8 @@ test_that("plot,XChromatogram works", {
 })
 
 test_that("filterMz,filterRt,XChromatogram work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr <- Chromatogram(rtime = 1:10,
                         intensity = c(4, 12, 18, 24, 23, 18, 15, 3, 2, 5))
     xchr <- as(chr, "XChromatogram")
@@ -108,6 +116,8 @@ test_that("filterMz,filterRt,XChromatogram work", {
 })
 
 test_that("hasChromPeaks,XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr <- Chromatogram(rtime = 1:10,
                         intensity = c(4, 12, 18, 24, 23, 18, 15, 3, 2, 5))
     xchr <- as(chr, "XChromatogram")
@@ -125,6 +135,8 @@ test_that("hasChromPeaks,XChromatogram works", {
 })
 
 test_that("removeIntensity,XChromatogram(s) works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -175,6 +187,8 @@ test_that("removeIntensity,XChromatogram(s) works", {
 })
 
 test_that("filterChromPeaks,XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- chromatogram(xod_x, mz = rbind(305.1 + c(-0.01, 0.01),
                                            462.2 + c(-0.04, 0.04)))
     res <- filterChromPeaks(chrs[1, 1], n = 1L, by = "keepTop")

--- a/tests/testthat/test_methods-XChromatograms.R
+++ b/tests/testthat/test_methods-XChromatograms.R
@@ -1,4 +1,6 @@
 test_that("chromPeaks, chromPeakData for XChromatograms work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     pks1 <- matrix(c(3, 2, 4, 339.2, 343, NA), nrow = 1,
                    dimnames = list(NULL, .CHROMPEAKS_REQ_NAMES))
     chr1 <- XChromatogram(
@@ -53,6 +55,8 @@ test_that("chromPeaks, chromPeakData for XChromatograms work", {
 })
 
 test_that("filterRt, filterMz for XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chr1 <- XChromatogram()
     chr2 <- XChromatogram(rtime = 1:4, intensity = c(45, 3, 34, 2))
     pks3 <- matrix(c(3, 2, 4, 145, 54, NA), nrow = 1,
@@ -134,6 +138,8 @@ test_that("filterRt, filterMz for XChromatograms works", {
 })
 
 test_that("plot,XChromatogram works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     rtr <- matrix(c(2700, 2900, 2600, 2750), ncol = 2, byrow = TRUE)
 
@@ -178,6 +184,8 @@ test_that("plot,XChromatogram works", {
 })
 
 test_that("processHistory,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     xchrs <- chromatogram(xod_xgrg, mz = mzr, rt = c(2600, 3600))
     res <- processHistory(xchrs)
@@ -192,6 +200,8 @@ test_that("processHistory,XChromatograms works", {
 })
 
 test_that("groupChromPeaks,XChromatograms,PeakDensityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     xchrs <- chromatogram(xod_xgrg, mz = mzr, rt = c(2600, 3600))
     param <- PeakDensityParam(sampleGroups = c(1, 1, 1))
@@ -224,6 +234,8 @@ test_that("groupChromPeaks,XChromatograms,PeakDensityParam works", {
 })
 
 test_that("dropFeatureDefinitions,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     xchrs <- chromatogram(xod_xgrg, mz = mzr, rt = c(2600, 3600))
     param <- PeakDensityParam(sampleGroups = c(1, 1, 1))
@@ -239,6 +251,8 @@ test_that("dropFeatureDefinitions,XChromatograms works", {
 })
 
 test_that("featureDefinitions,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     xchrs <- chromatogram(xod_xgrg, mz = mzr, rt = c(2600, 3600))
     param <- PeakDensityParam(sampleGroups = c(1, 1, 1))
@@ -257,6 +271,8 @@ test_that("featureDefinitions,XChromatograms works", {
 })
 
 test_that("[,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- findChromPeaks(od_chrs, param = CentWaveParam())
     prm <- PeakDensityParam(sampleGroups = c(1, 1, 1))
     chrs <- groupChromPeaks(chrs, param = prm)
@@ -356,6 +372,8 @@ test_that("[,XChromatograms works", {
 })
 
 test_that("featureValues,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- as(od_chrs, "XChromatograms")
     expect_error(featureValues(chrs))
     chrs <- findChromPeaks(chrs, param = CentWaveParam())
@@ -399,6 +417,8 @@ test_that("featureValues,XChromatograms works", {
 })
 
 test_that("plotChromPeakDensity,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- as(od_chrs, "XChromatograms")
     chrs <- findChromPeaks(chrs, param = CentWaveParam())
     prm <- PeakDensityParam(sampleGroups = c(1, 1, 1))
@@ -420,6 +440,8 @@ test_that("plotChromPeakDensity,XChromatograms works", {
 })
 
 test_that("dropFilledChromPeaks,XChromatogram and XChromatograms work", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## With filled-in data
     mzr <- matrix(c(335, 335, 344, 344), ncol = 2, byrow = TRUE)
     rtr <- matrix(c(2700, 2900, 2600, 2750), ncol = 2, byrow = TRUE)
@@ -466,6 +488,8 @@ test_that("dropFilledChromPeaks,XChromatogram and XChromatograms work", {
 })
 
 test_that("refineChromPeaks,XChromatograms,MergeNeighboringPeaksParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- 305.1 + c(-0.01, 0.01)
     chr <- chromatogram(filterFile(xod_x, 1), mz = mzr)
     res <- refineChromPeaks(chr, MergeNeighboringPeaksParam())
@@ -497,6 +521,8 @@ test_that("refineChromPeaks,XChromatograms,MergeNeighboringPeaksParam works", {
 })
 
 test_that("filterColumnsIntensityAbove,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- rbind(305.1 + c(-0.01, 0.01),
                  462.2 + c(-0.04, 0.04))
     chrs <- chromatogram(xod_x, mz = mzr)
@@ -517,6 +543,8 @@ test_that("filterColumnsIntensityAbove,XChromatograms works", {
 })
 
 test_that("filterColumnsKeepTop,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     mzr <- rbind(305.1 + c(-0.01, 0.01),
                  462.2 + c(-0.04, 0.04))
     chrs <- chromatogram(xod_x, mz = mzr)
@@ -533,6 +561,8 @@ test_that("filterColumnsKeepTop,XChromatograms works", {
 })
 
 test_that("filterChromPeaks,XChromatograms works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     chrs <- chromatogram(xod_x, mz = rbind(305.1 + c(-0.01, 0.01),
                                            462.2 + c(-0.04, 0.04)))
     res <- filterChromPeaks(chrs, n = 2L)

--- a/tests/testthat/test_methods-group-features.R
+++ b/tests/testthat/test_methods-group-features.R
@@ -5,6 +5,8 @@ xodgg <- groupFeatures(xodgg, param = AbundanceSimilarityParam(threshold = 0.3))
 
 
 test_that("featureGroups,featureGroups<-,XCMSnExp works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     expect_error(featureGroups(xod_x), "Please run")
     res <- featureGroups(xodg)
     expect_true(all(is.na(res)))
@@ -17,6 +19,8 @@ test_that("featureGroups,featureGroups<-,XCMSnExp works", {
 })
 
 test_that("SimilarRtimeParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     prm <- SimilarRtimeParam(3)
 
     expect_error(groupFeatures(xod_x, prm), "No feature definitions")
@@ -53,6 +57,8 @@ test_that("SimilarRtimeParam works", {
 })
 
 test_that("AbundanceSimilarityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     prm <- AbundanceSimilarityParam(threshold = 0.5, value = "maxo")
     expect_equal(prm@threshold, 0.5)
     expect_equal(prm@dots, list(value = "maxo"))
@@ -95,6 +101,8 @@ test_that("AbundanceSimilarityParam works", {
 })
 
 ## test_that("featureGroupPseudoSpectrum works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 ##     fvals <- featureValues(xodgg, method = "maxint", value = "maxo")
 ##     ## 3 feature
 ##     ft_idx <- which(featureGroups(xodgg) == "FG.010.001")
@@ -126,6 +134,8 @@ test_that("AbundanceSimilarityParam works", {
 ## })
 
 ## test_that("featureGroupFullScan works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 ##     fvals <- featureValues(xodgg, method = "maxint", value = "maxo")
 ##     ## 3 feature
 ##     res <- featureGroupFullScan("FG.010.001", xodgg, fvals = fvals)
@@ -147,6 +157,8 @@ test_that("AbundanceSimilarityParam works", {
 ## })
 
 ## test_that("featureGroupSpectra works", {
+    skip_on_os(os = "windows", arch = "i386")
+
 ##     ## Errors
 ##     expect_error(featureGroupSpectra(xodgg, subset = 1:5), "an integer")
 ##     expect_error(featureGroupSpectra(xod), "feature definitions")
@@ -174,6 +186,8 @@ test_that("AbundanceSimilarityParam works", {
 ## })
 
 test_that(".group_eic_similarity works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     set.seed(123)
     chr1 <- Chromatogram(rtime = 1:10 + rnorm(n = 10, sd = 0.3),
                          intensity = c(5, 29, 50, NA, 100, 12, 3, 4, 1, 3))
@@ -220,6 +234,8 @@ test_that(".group_eic_similarity works", {
 })
 
 test_that("EicSimilarityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     res <- EicSimilarityParam()
     expect_equal(res@threshold, 0.9)
     expect_equal(res@ALIGNFUNARGS, list(tolerance = 0, method = "closest"))
@@ -255,6 +271,8 @@ test_that("EicSimilarityParam works", {
 })
 
 test_that("groupFeatures,EicSimilarityParam works", {
+    skip_on_os(os = "windows", arch = "i386")
+
     ## n bigger than 3
     expect_error(groupFeatures(xodg, param = EicSimilarityParam(n = 5)),
                  "smaller than or")


### PR DESCRIPTION
This may be changing/fixing too much at once (with cannons on sparrows) but the release is approaching fast.