### PR TITLE
Fix peak mz

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.17.4
+Version: 3.17.5
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/R/do_findChromPeaks-functions.R
+++ b/R/do_findChromPeaks-functions.R
@@ -374,7 +374,7 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
         idxs <- which(eic$scan %in% seq(scrange[1], scrange[2]))
         mzROI.EIC <- list(scan=eic$scan[idxs], intensity=eic$intensity[idxs])
         ## mzROI.EIC <- rawEIC(object,mzrange=mzrange,scanrange=scrange)
-        omz <- .Call("getMZ", mz, int, scanindex, as.double(mzrange),
+        omz <- .Call("getWeightedMZ", mz, int, scanindex, as.double(mzrange),
                      as.integer(scrange), as.integer(length(scantime)),
                      PACKAGE = 'xcms')
         ## omz <- rawMZ(object,mzrange=mzrange,scanrange=scrange)
@@ -908,7 +908,7 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
         ## original mzROI range
         idxs <- which(eic$scan %in% seq(scrange[1], scrange[2]))
         mzROI.EIC <- list(scan=eic$scan[idxs], intensity=eic$intensity[idxs])
-        omz <- .Call("getMZ", mz, int, scanindex, as.double(mzrange),
+        omz <- .Call("getWeightedMZ", mz, int, scanindex, as.double(mzrange),
                      as.integer(scrange), as.integer(length(scantime)),
                      PACKAGE = 'xcms')
         if (all(omz == 0)) {

--- a/R/do_findChromPeaks-functions.R
+++ b/R/do_findChromPeaks-functions.R
@@ -338,6 +338,9 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
     Nscantime <- length(scantime)
     lf <- length(roiList)
 
+    ## @JO REMOVEME
+    mz_fun <- getOption("MZFUN", default = "getMZ")
+
     ## cat('\n Detecting chromatographic peaks ... \n % finished: ')
     ## lp <- -1
     message("Detecting chromatographic peaks in ", length(roiList),
@@ -374,7 +377,7 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
         idxs <- which(eic$scan %in% seq(scrange[1], scrange[2]))
         mzROI.EIC <- list(scan=eic$scan[idxs], intensity=eic$intensity[idxs])
         ## mzROI.EIC <- rawEIC(object,mzrange=mzrange,scanrange=scrange)
-        omz <- .Call("getWeightedMZ", mz, int, scanindex, as.double(mzrange),
+        omz <- .Call(mz_fun, mz, int, scanindex, as.double(mzrange),
                      as.integer(scrange), as.integer(length(scantime)),
                      PACKAGE = 'xcms')
         ## omz <- rawMZ(object,mzrange=mzrange,scanrange=scrange)
@@ -881,6 +884,8 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
     Nscantime <- length(scantime)
     lf <- length(roiList)
 
+    #' @JO REMOVEME
+    mz_fun <- getOption("MZFUN", default = "getMZ")
     ## cat('\n Detecting chromatographic peaks ... \n % finished: ')
     ## lp <- -1
     message("Detecting chromatographic peaks in ", length(roiList),
@@ -908,7 +913,7 @@ do_findChromPeaks_centWave <- function(mz, int, scantime, valsPerSpect,
         ## original mzROI range
         idxs <- which(eic$scan %in% seq(scrange[1], scrange[2]))
         mzROI.EIC <- list(scan=eic$scan[idxs], intensity=eic$intensity[idxs])
-        omz <- .Call("getWeightedMZ", mz, int, scanindex, as.double(mzrange),
+        omz <- .Call(mz_fun, mz, int, scanindex, as.double(mzrange),
                      as.integer(scrange), as.integer(length(scantime)),
                      PACKAGE = 'xcms')
         if (all(omz == 0)) {

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,6 +1,14 @@
 Changes in version 3.17.4
 
 - Add `transformIntensity` method.
+- Change the way the m/z value for a chromatographic peak is determined by
+  centWave: if a ROI contains more than one peak for one scan (spectrum) an
+  intensity-weighted m/z is reported for that scan. The m/z of the
+  chromatographic peak is then calculated based on these reported m/z values for
+  each scan (spectrum). In the original version the mean m/z for a scan was
+  reported instead. As a result, m/z values of chromatographic peaks are now
+  slightly different but are expected to be more accurate. See
+  https://github.com/sneumann/xcms/issues/590 for more details.
 
 Changes in version 3.17.3
 


### PR DESCRIPTION
This PR changes the way centWave calculates the m/z of a peak if within the ROI there are more than one mass peak per spectrum. In theory, for well centroided data, this should not happen but can happen sometimes.

The default was to simply calculate the mean m/z across all peaks per spectrum (retention times) within the ROI. This PR changes this and uses a intensity weighted mean instead of the plain mean. This should fix issue #590