### PR TITLE
feat: add parameter expandMz to featureChromatograms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.17.4
+Version: 3.17.5
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,
@@ -70,7 +70,8 @@ Suggests:
     pheatmap,
     Spectra (>= 1.1.17),
     MsBackendMgf,
-    progress
+    progress,
+    signal
 Enhances:
     Rgraphviz,
     rgl,

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -2311,6 +2311,13 @@ featureSpectra <- function(x, msLevel = 2L, expandRt = 0, expandMz = 0,
 #'
 #' @param x `XCMSnExp` object with grouped chromatographic peaks.
 #'
+#' @param expandMz `numeric(1)` to expand the m/z range for each chromatographic
+#'     peak by a constant value on each side. Be aware that by extending the
+#'     m/z range the extracted EIC might **no longer** represent the actual
+#'     identified chromatographic peak because intensities of potential
+#'     additional mass peaks within each spectra would be aggregated into the
+#'     final reported intensity value per spectrum (retention time).
+#'
 #' @param expandRt `numeric(1)` to expand the retention time range for each
 #'     chromatographic peak by a constant value on each side.
 #'
@@ -2383,7 +2390,8 @@ featureChromatograms <- function(x, expandRt = 0, aggregationFun = "max",
                                              "any", "all"),
                                  filled = FALSE,
                                  n = length(fileNames(x)),
-                                 value = c("maxo", "into"), ...) {
+                                 value = c("maxo", "into"),
+                                 expandMz = 0, ...) {
     include <- match.arg(include)
     value <- match.arg(value)
     if (!hasFeatures(x))
@@ -2437,6 +2445,8 @@ featureChromatograms <- function(x, expandRt = 0, aggregationFun = "max",
         include_peaks <- "any"
     mat[, 1] <- mat[, 1] - expandRt
     mat[, 2] <- mat[, 2] + expandRt
+    mat[, 3] <- mat[, 3] - expandMz
+    mat[, 4] <- mat[, 4] + expandMz
     colnames(mat) <- c("rtmin", "rtmax", "mzmin", "mzmax")
     chrs <- chromatogram(x, rt = mat[, 1:2], mz = mat[, 3:4],
                          aggregationFun = aggregationFun, filled = filled,
@@ -3086,7 +3096,7 @@ reconstructChromPeakSpectra <- function(object, expandRt = 0, diffRt = 2,
         adjustedRtime(newFd) <- adjustedRtime(object, bySample = TRUE)[file]
     if (has_chrom_peaks) {
         pks <- chromPeaks(object)
-        idx <- base::which(pks[, "sample"] %in% file)
+        idx <- pks[, "sample"] %in% file
         pks <- pks[idx, , drop = FALSE]
         pks[, "sample"] <- match(pks[, "sample"], file)
         if (has_features) {

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,8 @@
+Changes in version 3.17.5
+
+- Add parameter `expandMz` to `featureChromatograms`
+  (https://github.com/sneumann/xcms/issues/612).
+
 Changes in version 3.17.4
 
 - Add `transformIntensity` method.

--- a/man/featureChromatograms.Rd
+++ b/man/featureChromatograms.Rd
@@ -13,6 +13,7 @@ featureChromatograms(
   filled = FALSE,
   n = length(fileNames(x)),
   value = c("maxo", "into"),
+  expandMz = 0,
   ...
 )
 }
@@ -47,6 +48,13 @@ from which the EIC should be extracted.}
 \item{value}{\code{character(1)} specifying the column to be used to sort the
 samples. Can be either \code{"maxo"} (the default) or \code{"into"} to use the
 maximal peak intensity or the integrated peak area, respectively.}
+
+\item{expandMz}{\code{numeric(1)} to expand the m/z range for each chromatographic
+peak by a constant value on each side. Be aware that by extending the
+m/z range the extracted EIC might \strong{no longer} represent the actual
+identified chromatographic peak because intensities of potential
+additional mass peaks within each spectra would be aggregated into the
+final reported intensity value per spectrum (retention time).}
 
 \item{...}{optional arguments to be passed along to the \code{\link[=chromatogram]{chromatogram()}}
 function.}

--- a/tests/testthat/test_functions-XCMSnExp.R
+++ b/tests/testthat/test_functions-XCMSnExp.R
@@ -375,6 +375,13 @@ test_that("featureChromatograms works", {
     expect_error(featureChromatograms(xod_xgrg, features = c(100000, 1000002)))
     expect_error(featureChromatograms(xod_xgrg, features = c("a", "FT02")))
 
+    ## expandMz
+    res_4 <- featureChromatograms(xod_xgrg, features = c("FT01", "FT05"),
+                                  expandMz = 2)
+    expect_equal(mz(res_4)[1, ], mz(res_3)[1, ] + c(-2, 2))
+    expect_true(sum(is.na(intensity(res_4[1, 2]))) <
+                sum(is.na(intensity(res_3[1, 2]))))
+
     ## Test with filled-in peaks.
     xod_tmp <- groupChromPeaks(
         xod_xgr, param = PeakDensityParam(sampleGroups = rep(1, 3),

--- a/vignettes/xcms-direct-injection.Rmd
+++ b/vignettes/xcms-direct-injection.Rmd
@@ -12,7 +12,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteKeywords{Mass Spectrometry, MS, Metabolomics, Bioinformatics}
   %\VignetteEncoding{UTF-8}
-  %\VignetteDepends{xcms,msdata,MassSpecWavelet,BiocStyle}
+  %\VignetteDepends{xcms,msdata,MassSpecWavelet,BiocStyle,signal}
 ---
 
 ```{r style, echo = FALSE, results = 'asis'}


### PR DESCRIPTION
- Add parameter `expandMz` to `featureChromatorgrams` (#612).
- Add package `signal` to Suggests and to the direct injection vignette to ensure the package is installed (seems to be now a dependency of the `CWT` package. 