### PR TITLE
[DOC] Replace links to MassSpecWavelet::sav.gol() with links to peakDetectionCWT()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     RColorBrewer,
     plyr,
     RANN,
-    MassSpecWavelet (>= 1.5.2),
+    MassSpecWavelet (>= 1.61.3),
     S4Vectors,
     robustbase,
     IRanges,

--- a/R/functions-Params.R
+++ b/R/functions-Params.R
@@ -170,15 +170,15 @@ MassifquantParam <- function(ppm = 25, peakwidth = c(20, 50), snthresh = 10,
 #'
 #' @param peakThr numeric(1) with the minimum absolute intensity
 #'     (above baseline) of peaks to be picked. If provided, the smoothing
-#'     function \code{\link{sav.gol}} function (in the \code{MassSpecWavelet})
-#'     package is called to estimate the local intensity.
+#'     Savitzky-Golay filter is used (in the \code{MassSpecWavelet})
+#'     package to estimate the local intensity.
 #'
 #' @param tuneIn logical(1) whther to tune in the parameter
 #'     estimation of the detected peaks.
 #'
 #' @param ... Additional parameters to be passed to the
-#'     \code{\link{identifyMajorPeaks}} and
-#'     \code{\link{sav.gol}} functions from the
+#'     \code{\link{peakDetectionCWT}} and
+#'     \code{\link{identifyMajorPeaks}} functions from the
 #'     \code{MassSpecWavelet} package.
 #'
 #' @return The \code{MSWParam} function returns a \code{MSWParam}

--- a/R/methods-Params.R
+++ b/R/methods-Params.R
@@ -798,7 +798,7 @@ setReplaceMethod("tuneIn", "MSWParam", function(object, value) {
 #'     \code{addParams} slot of the object. This slot stores optional additional
 #'     parameters to be passed to the
 #'     \code{\link{identifyMajorPeaks}} and
-#'     \code{\link{sav.gol}} functions from the
+#'     \code{\link{peakDetectionCWT}} functions from the
 #'     \code{MassSpecWavelet} package.
 #'
 #' @rdname findPeaks-MSW


### PR DESCRIPTION
Hi,

I recently started maintaining the MassSpecWavelet package, a dependency of xcms.

My roadmap is to maintain MassSpecWavelet making zero changes, or very minimal if I have to. I believe it is a rather old and stable package and I like it that way.

However, I have found a bug in the Savitzky-Golay filter implemented there, that affects the boundaries of the signal. It's not a serious issue, since given a filter of length N it only affects the N/2 first and last points of the signal, but still I wanted to correct it.

The `MassSpecWavelet:::sav.gol()` function was not exported, so it was easy to make all the necessary changes without concerns of breaking other packages. With respect to code I used a `Suggests: signal` and I used the `signal::sgolayfilt()` function instead, which has been stable for the last decade at least as well.

With respect to the documentation, `sav.gol()`  had a `man/` page and xcms is referencing it. I did not want to break your man pages, so I just created an alias that redirects `sav.gol` to the `peakDetectionCWT`, which is the relevant function that calls the Savitzky-Golay filter.

These changes are all released in MassSpecWavelet in the current (3.15) Bioconductor release.

This pull request replaces references to the sav.gol page from the XCMS package. I would appreciate if you merge it so I can remove the sav.gol alias from MassSpecWavelet in a future version, effectively removing all references to sav.gol.

See https://github.com/zeehio/MassSpecWavelet/issues/2 for further details on this issue.

Thanks for your time!