### PR TITLE
refactor: chromatogram,XcmsExperiment with only mz or rt defined

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.99.4
+Version: 3.99.5
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1917,6 +1917,10 @@ setMethod(
                     "'chromPeaks' instead")
             chromPeaks <- include
         }
+        if (nrow(mz) && !nrow(rt))
+            rt <- cbind(rep(-Inf, nrow(mz)), rep(Inf, nrow(mz)))
+        if (nrow(rt) && !nrow(mz))
+            mz <- cbind(rep(-Inf, nrow(rt)), rep(Inf, nrow(rt)))
         return.type <- match.arg(return.type)
         chromPeaks <- match.arg(chromPeaks)
         if (hasAdjustedRtime(object))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,9 @@
+Changes in version 3.99.5
+----------------------
+
+- Only `mz` or `rt` need to be provided for `chromatograms`.
+
+
 Changes in version 3.99.4
 ----------------------
 

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1090,6 +1090,35 @@ test_that("chromatogram,XcmsExperiment and .xmse_extract_chromatograms_old", {
                         rt = c(100, 600), isolationWindowTargetMz = 270.85,
                         aggregationFun = "sum")
     expect_true(all(intensity(res[[1L]]) > 0))
+
+    ## Defining only mz or rt.
+    rtr <- c(2600, 2700)
+    mzr <- c(340, 400)
+    res <- chromatogram(xmse, mz = mzr)
+    expect_s4_class(res, "XChromatograms")
+    expect_true(nrow(res) == 1L)
+    expect_true(nrow(chromPeaks(res)) > 0)
+    expect_true(all(chromPeaks(res)[, "mz"] >= 340 &
+                    chromPeaks(res)[, "mz"] <= 400))
+    expect_true(all(chromPeaks(res[1, 1])[, "sample"] == 1L))
+    expect_true(all(chromPeaks(res[1, 2])[, "sample"] == 2L))
+    expect_true(all(chromPeaks(res[1, 3])[, "sample"] == 3L))
+    rrt <- range(lapply(res, rtime))
+    expect_true(rrt[1] < 2600)
+    expect_true(rrt[2] > 4400)
+
+    res <- chromatogram(xmse, rt = rtr)
+    expect_s4_class(res, "XChromatograms")
+    expect_true(nrow(res) == 1L)
+    expect_true(nrow(chromPeaks(res)) > 0)
+    expect_true(any(chromPeaks(res)[, "mz"] < 340 |
+                    chromPeaks(res)[, "mz"] > 400))
+    expect_true(all(chromPeaks(res[1, 1])[, "sample"] == 1L))
+    expect_true(all(chromPeaks(res[1, 2])[, "sample"] == 2L))
+    expect_true(all(chromPeaks(res[1, 3])[, "sample"] == 3L))
+    rrt <- range(lapply(res, rtime))
+    expect_true(rrt[1] >= 2600)
+    expect_true(rrt[2] <= 2700)
 })
 
 test_that("featureChromatograms,XcmsExperiment works", {


### PR DESCRIPTION
- Either `mz` or `rt` need to be provided for `chromatogram,XcmsExperiment`, but not both.