### PR TITLE
fix: add method to coerce XcmsExperiment to xcmsSet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 3.99.5
+Version: 3.99.6
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/R/MsExperiment.R
+++ b/R/MsExperiment.R
@@ -99,6 +99,10 @@ setMethod(
             rt <- matrix(rt, ncol = 2L)
         if (!is.matrix(mz))
             mz <- matrix(mz, ncol = 2L)
+        if (nrow(mz) && !nrow(rt))
+            rt <- cbind(rep(-Inf, nrow(mz)), rep(Inf, nrow(mz)))
+        if (nrow(rt) && !nrow(mz))
+            mz <- cbind(rep(-Inf, nrow(rt)), rep(Inf, nrow(rt)))
         .mse_chromatogram(
             object, rt = rt, mz = mz, aggregationFun = aggregationFun,
             msLevel = msLevel, isolationWindow = isolationWindowTargetMz,

--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -1459,6 +1459,9 @@ setMethod("smooth", "XCMSnExp", function(x, method = c("SavitzkyGolay",
 #' @name XCMSnExp-class
 setAs(from = "XCMSnExp", to = "xcmsSet", def = .XCMSnExp2xcmsSet)
 
+#' @rdname XcmsExperiment
+setAs(from = "XcmsExperiment", to = "xcmsSet", def = .XCMSnExp2xcmsSet)
+
 #' @rdname XCMSnExp-peak-grouping-results
 setMethod("quantify", "XCMSnExp", function(object, ...) {
     .XCMSnExp2SummarizedExperiment(object, ...)

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,7 +1,14 @@
+Changes in version 3.99.6
+----------------------
+
+- Add method to coerce a `XcmsExperiment` to a `xcmsSet` (issue #696).
+- Support providing only `mz` or `rt` also for `chromatogram,MsExperiment`.
+
+
 Changes in version 3.99.5
 ----------------------
 
-- Only `mz` or `rt` need to be provided for `chromatograms`.
+- Only `mz` or `rt` need to be provided for `chromatogram`.
 
 
 Changes in version 3.99.4

--- a/tests/testthat/test_MsExperiment.R
+++ b/tests/testthat/test_MsExperiment.R
@@ -77,6 +77,11 @@ test_that("chromatogram,MsExperiment works", {
     expect_equal(intensity(res[1, 1]), numeric())
     expect_equal(intensity(res[1, 2]), numeric())
     expect_equal(intensity(res[1, 2]), numeric())
+
+    res <- chromatogram(mse, rt = rbind(c(3000, 3500), c(4000, 4500)))
+    expect_equal(nrow(res), 2)
+    res <- chromatogram(mse, mz = rbind(c(200, 210), c(330, 331)))
+    expect_equal(nrow(res), 2)
 })
 
 test_that("uniqueMsLevels,MsExperiment works", {

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1320,3 +1320,9 @@ test_that("chromPeaksChromatograms,XcmsExperiment works", {
     ints <- vapply(res, function(z) sum(intensity(z), na.rm = TRUE), numeric(1))
     expect_true(cor(chromPeaks(res)[, "into"], ints) >= 0.97)
 })
+
+test_that("setAs,XcmsExperiment,xcmsSet works", {
+    res <- as(xmseg, "xcmsSet")
+    expect_s4_class(res, "xcmsSet")
+    expect_equal(peaks(res), chromPeaks(xmseg))
+})


### PR DESCRIPTION
- Add method to coerce a `XcmsExperiment` to a `xcmsSet` (issue #696).
- Fix `chromatogram,MsExperiment` to support also defining either `mz` or `rt`.