### PR TITLE
fix issue #716 in XcmsExperiment-functions.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Authors@R: c(
 	   person(given = "Philippine", family = "Louail",
 	   email = "philippine.louail@eurac.edu",
 	   role = "aut",
-	   comment = c(ORCID = "0009-0007-5429-6846"))
+	   comment = c(ORCID = "0009-0007-5429-6846")),
 	   person(given = "Pablo", family = "Vangeenderhuysen",
 	   email = "pablo.vangeenderhuysen@ugent.be",
 	   role = "ctb",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.1.7
+Version: 4.1.8
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Authors@R: c(
 	   email = "philippine.louail@eurac.edu",
 	   role = "aut",
 	   comment = c(ORCID = "0009-0007-5429-6846"))
-	   )
 	   person(given = "Pablo", family = "Vangeenderhuysen",
 	   email = "pablo.vangeenderhuysen@ugent.be",
 	   role = "ctb",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,11 @@ Authors@R: c(
 	   role = "aut",
 	   comment = c(ORCID = "0009-0007-5429-6846"))
 	   )
+	   person(given = "Pablo", family = "Vangeenderhuysen",
+	   email = "pablo.vangeenderhuysen@ugent.be",
+	   role = "ctb",
+	   comment = c(ORCID = "0000-0002-5492-6904"))
+	   )
 Depends:
     R (>= 4.0.0),
     BiocParallel (>= 1.8.0),

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -503,7 +503,6 @@
                                            mzCenterFun = "weighted.mean",
                                            sampleIndex = integer(),
                                            cn = character(), ...) {
-    cn = c(cn,"sn") 
     res <- matrix(NA_real_, ncol = length(cn), nrow = nrow(peakArea))
     rownames(res) <- rownames(peakArea)
     colnames(res) <- cn
@@ -526,11 +525,10 @@
                 maxi <- which.max(mat[, 2L])[1L]
                 mmz <- do.call(mzCenterFun, list(mat[, 1L], mat[, 2L]))
                 if (is.na(mmz)) mmz <- mat[maxi, 1L]
-                res[i, c("rt", "mz", "maxo", "into","sn")] <- c(
+                res[i, c("rt", "mz", "maxo", "into")] <- c(
                     rts[maxi], mmz, mat[maxi, 2L],
                     sum(mat[, 2L], na.rm = TRUE) *
-                    ((rtr[2L] - rtr[1L]) / max(1L, (length(keep) - 1L))),
-                    mat[maxi, 2L]/ estimateChromNoise(mat[, 2L])
+                    ((rtr[2L] - rtr[1L]) / max(1L, (length(keep) - 1L)))
                 )
                 if ("beta_cor" %in% cn)
                     res[i, c("beta_cor", "beta_snr")] <- .get_beta_values(

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -503,6 +503,7 @@
                                            mzCenterFun = "weighted.mean",
                                            sampleIndex = integer(),
                                            cn = character(), ...) {
+    cn = c(cn,"sn") 
     res <- matrix(NA_real_, ncol = length(cn), nrow = nrow(peakArea))
     rownames(res) <- rownames(peakArea)
     colnames(res) <- cn
@@ -525,10 +526,11 @@
                 maxi <- which.max(mat[, 2L])[1L]
                 mmz <- do.call(mzCenterFun, list(mat[, 1L], mat[, 2L]))
                 if (is.na(mmz)) mmz <- mat[maxi, 1L]
-                res[i, c("rt", "mz", "maxo", "into")] <- c(
+                res[i, c("rt", "mz", "maxo", "into","sn")] <- c(
                     rts[maxi], mmz, mat[maxi, 2L],
                     sum(mat[, 2L], na.rm = TRUE) *
-                    ((rtr[2L] - rtr[1L]) / max(1L, (length(keep) - 1L)))
+                    ((rtr[2L] - rtr[1L]) / max(1L, (length(keep) - 1L))),
+                    mat[maxi, 2L]/ estimateChromNoise(mat[, 2L])
                 )
                 if ("beta_cor" %in% cn)
                     res[i, c("beta_cor", "beta_snr")] <- .get_beta_values(

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -702,7 +702,7 @@
 NULL
 
 .empty_chrom_peaks <- function(sample = TRUE) {
-    cols <- c(.REQ_PEAKS_COLS, "maxo")
+    cols <- c(.REQ_PEAKS_COLS, "maxo","sn")
     if (!sample)
         cols <- cols[cols != "sample"]
     matrix(numeric(), ncol = length(cols), nrow = 0,

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,8 @@
+Changes in version 4.1.8
+----------------------
+- Fixing issue #716: edit of `.empty_chrom_peaks` function so an `sn` column is
+  returned. Fixes extracting and plotting of peaks after using `manualChromPeaks`
+
 Changes in version 4.1.7
 ----------------------
 

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -4,7 +4,7 @@ mse_dia <- readMsExperiment(fl)
 test_that(".empty_chrom_peaks works", {
     res <- .empty_chrom_peaks()
     expect_true(nrow(res) == 0)
-    expect_equal(colnames(res), c(.REQ_PEAKS_COLS, "maxo"))
+    expect_equal(colnames(res), c(.REQ_PEAKS_COLS, "maxo","sn"))
 
     res <- .empty_chrom_peaks(sample = FALSE)
     expect_true(nrow(res) == 0)
@@ -995,8 +995,13 @@ test_that("manualChromPeaks,XcmsExperiment works", {
     expect_equal(unname(pks[, c("mz", "into", "maxo")]),
                  unname(pks_2[, c("mz", "into", "maxo")]))
 
+    chr_pks <- chromPeaks(res)
+    expect_true("sn" %in% colnames(chr_pks)
+
     res2 <- manualChromPeaks(tmp, pks, samples = 2)
     expect_equal(unname(chromPeaks(res2)), unname(pks_2))
+
+    
 })
 
 test_that("filterChromPeaks,XcmsExperiment works", {


### PR DESCRIPTION
As mentioned in issue #716: I tried to implement a fix that makes sure the `sn` column also appears when using the `manualChromPeaks` function so that other function to extract and plot the `XChromatograms` objects work. Noise estimation happens using the `estimateChromNoise` function, feel free to suggest better ways to implement this. 