### PR TITLE
fix: add parameter rtimeDifferenceThreshold for ObiwarpParam

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.1.12
+Version: 4.1.13
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # xcms 4.1
 
+## Changes in version 4.1.13
+
+- Add parameter `rtimeDifferenceThreshold` to `ObiwarpParam` allowing to
+  customize the threshold used by obiwarp to determine whether *gaps* are
+  present in the sequence of retention times of a sample. This addresses/fixes
+  issue #739.
+
 ## Changes in version 4.1.12
 
 - Implementation of the `LamaParama` class and method for the `adjustRtime()`

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -194,6 +194,18 @@ setGeneric("addProcessHistory", function(object, ...)
 #'     start and end points and `response = 100` warping using all bijective
 #'     anchors.
 #'
+#' @param rtimeDifferenceThreshold For `ObiwarpParam`: `numeric(1)` defining
+#'     the threshold to identify a *gap* in the sequence of retention times of
+#'     (MS1) spectra of a sample/file. A gap is defined if the difference in
+#'     retention times between consecutive spectra is
+#'     `> rtimeDifferenceThreshold` of the median observed difference or
+#'     retenion times of that data sample/file. Spectra with an retention time
+#'     after such a *gap* will not be adjusted. The default for this parameter
+#'     is `rtimeDifferenceThreshold = 5`. For Waters data with lockmass scans
+#'     or LC-MS/MS data this might however be a too low threshold and it should
+#'     be increased. See also
+#'     [issue #739](https://github.com/sneumann/xcms/issues/739).
+#'
 #' @param smooth For `PeakGroupsParam`: `character(1)` defining the function to
 #'     be used to interpolate corrected retention times for all peak groups.
 #'     Can be either `"loess"` or `"linear"`.

--- a/R/DataClasses.R
+++ b/R/DataClasses.R
@@ -1522,7 +1522,8 @@ setClass("ObiwarpParam",
                    localAlignment = "logical",
                    initPenalty = "numeric",
                    subset = "integer",
-                   subsetAdjust = "character"),
+                   subsetAdjust = "character",
+                   rtimeDifferenceThreshold = "numeric"),
          contains = "Param",
          prototype = prototype(
              binSize = 1,
@@ -1536,7 +1537,8 @@ setClass("ObiwarpParam",
              localAlignment = FALSE,
              initPenalty = 0,
              subset = integer(),
-             subsetAdjust = "average"),
+             subsetAdjust = "average",
+             rtimeDifferenceThreshold = 5),
          validity = function(object) {
              msg <- character()
              if (length(object@binSize) > 1 |

--- a/R/MsExperiment-functions.R
+++ b/R/MsExperiment-functions.R
@@ -333,6 +333,7 @@
 
 .mse_obiwarp_chunks <- function(x, param, msLevel = 1L, chunkSize = 1L,
                                 BPPARAM = bpparam()) {
+    message("value ", param@rtimeDifferenceThreshold)
     rt_raw <- split(rtime(x), fromFile(x))
     subset_idx <- subset(param)
     if (length(subset_idx))

--- a/R/functions-OnDiskMSnExp.R
+++ b/R/functions-OnDiskMSnExp.R
@@ -448,15 +448,15 @@ findPeaks_MSW_Spectrum_list <- function(x, method = "MSW", param) {
     ## median difference between spectras' scan time.
     mstdiff <- median(c(scantime1_diff, scantime2_diff), na.rm = TRUE)
 
-    mst1 <- which(scantime1_diff > 5 * mstdiff)[1]
+    mst1 <- which(scantime1_diff > param@rtimeDifferenceThreshold * mstdiff)[1]
     if (!is.na(mst1)) {
-        message("Found gaps in scan times of the center sample: cut ",
+        warning("Found gaps in scan times of the center sample: cut ",
                 "scantime-vector at ", scantime1[mst1]," seconds.")
         scantime1 <- scantime1[seq_len(max(2, (mst1 - 1)))]
     }
-    mst2 <- which(scantime2_diff > 5 * mstdiff)[1]
+    mst2 <- which(scantime2_diff > param@rtimeDifferenceThreshold * mstdiff)[1]
     if (!is.na(mst2)) {
-        message("Found gaps in scan time. Cutting scantime-vector at ",
+        warning("Found gaps in scan time. Cutting scantime-vector at ",
                 scantime2[mst2]," seconds.")
         scantime2 <- scantime2[seq_len(max(2, (mst2 - 1)))]
     }

--- a/R/functions-Params.R
+++ b/R/functions-Params.R
@@ -311,7 +311,8 @@ ObiwarpParam <- function(binSize = 1, centerSample = integer(), response = 1L,
                          gapExtend = numeric(), factorDiag = 2, factorGap = 1,
                          localAlignment = FALSE, initPenalty = 0,
                          subset = integer(),
-                         subsetAdjust = c("average", "previous")) {
+                         subsetAdjust = c("average", "previous"),
+                         rtimeDifferenceThreshold = 5) {
     subsetAdjust <- match.arg(subsetAdjust)
     new("ObiwarpParam", binSize = binSize,
         centerSample = as.integer(centerSample),
@@ -319,7 +320,8 @@ ObiwarpParam <- function(binSize = 1, centerSample = integer(), response = 1L,
         gapInit = gapInit, gapExtend = gapExtend, factorDiag = factorDiag,
         factorGap = factorGap, localAlignment = localAlignment,
         initPenalty = initPenalty, subset = as.integer(subset),
-        subsetAdjust = subsetAdjust)
+        subsetAdjust = subsetAdjust,
+        rtimeDifferenceThreshold = rtimeDifferenceThreshold[1L])
 }
 
 #' @return The \code{FillChromPeaksParam} function returns a

--- a/man/adjustRtime.Rd
+++ b/man/adjustRtime.Rd
@@ -117,7 +117,8 @@ ObiwarpParam(
   localAlignment = FALSE,
   initPenalty = 0,
   subset = integer(),
-  subsetAdjust = c("average", "previous")
+  subsetAdjust = c("average", "previous"),
+  rtimeDifferenceThreshold = 5
 )
 
 adjustRtimePeakGroups(object, param = PeakGroupsParam(), msLevel = 1L)
@@ -328,6 +329,18 @@ alignment should be performed instead of the default global alignment.}
 
 \item{initPenalty}{For \code{ObiwarpParam}: \code{numeric(1)} defining the penalty for
 initiating an alignment (for local alignment only).}
+
+\item{rtimeDifferenceThreshold}{For \code{ObiwarpParam}: \code{numeric(1)} defining
+the threshold to identify a \emph{gap} in the sequence of retention times of
+(MS1) spectra of a sample/file. A gap is defined if the difference in
+retention times between consecutive spectra is
+\verb{> rtimeDifferenceThreshold} of the median observed difference or
+retenion times of that data sample/file. Spectra with an retention time
+after such a \emph{gap} will not be adjusted. The default for this parameter
+is \code{rtimeDifferenceThreshold = 5}. For Waters data with lockmass scans
+or LC-MS/MS data this might however be a too low threshold and it should
+be increased. See also
+\href{https://github.com/sneumann/xcms/issues/739}{issue #739}.}
 
 \item{value}{The value for the slot.}
 


### PR DESCRIPTION
- Add a parameter `rtimeDifferenceThreshold` for `ObiwarpParam` to allow increasing the tolerance to define *gaps* in the sequence of retention times. This fixes issue #739.