### PR TITLE
fix: filtering MsLevel for xic plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.1.13
+Version: 4.1.14
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Changes in version 4.1.13
 
+- Fix for issue #734. XIC plot is is now working with MS2 Data.
+  
+
+## Changes in version 4.1.13
+
 - Add parameter `rtimeDifferenceThreshold` to `ObiwarpParam` allowing to
   customize the threshold used by obiwarp to determine whether *gaps* are
   present in the sequence of retention times of a sample. This addresses/fixes

--- a/R/XcmsExperiment-plotting.R
+++ b/R/XcmsExperiment-plotting.R
@@ -380,12 +380,13 @@ setMethod(
     fns <- basename(fileNames(x))
     for (i in seq_along(x)) {
         z <- x[i]
-        lst <- as(filterMsLevel(spectra(z), msLevel = msLevel), "list")
+        flt <- filterMsLevel(spectra(z), msLevel = msLevel)
+        lst <- as(flt, "list")
         lns <- lengths(lst) / 2
         lst <- do.call(rbind, lst)
         if (!length(lst))
             next
-        df <- data.frame(rt = rep(rtime(z), lns), lst)
+        df <- data.frame(rt = rep(rtime(flt), lns), lst)
         colnames(df)[colnames(df) == "intensity"] <- "i"
         do.call(MSnbase:::.plotXIC,
                 c(list(x = df, main = fns[i], layout = NULL), dots))

--- a/tests/testthat/test_XcmsExperiment-plotting.R
+++ b/tests/testthat/test_XcmsExperiment-plotting.R
@@ -4,6 +4,7 @@ df <- data.frame(mzML_file = basename(fls),
                  dataOrigin = fls,
                  sample = c("ko15", "ko16", "ko18"))
 mse <- readMsExperiment(spectraFiles = fls, sampleData = df)
+mse_ms2 <- readMsExperiment(msdata::proteomics(full.names=TRUE)[4])
 p <- CentWaveParam(noise = 10000, snthresh = 40, prefilter = c(3, 10000))
 xmse <- findChromPeaks(mse, param = p)
 pdp <- PeakDensityParam(sampleGroups = rep(1, 3))
@@ -50,4 +51,9 @@ test_that("plot,XcmsExperiment and .xmse_plot_xic works", {
 
     tmp <- filterMz(filterRt(xmse, rt = c(2550, 2800)), mz = c(342.5, 344.5))
     plot(tmp)
+})
+
+test_that(".xmse_plot_xic works with ms2 data", {
+  tmp <-  filterMz(filterRt(mse_ms2, rt= c(2160, 2190)), mz = c(990,1000))
+  plot(tmp)
 })


### PR DESCRIPTION
-  fix for iusse #734 
- `df` is now constructed using filtered data (`flt`)
- added test for plot with ms2 data 
