### PR TITLE
refactor: add storeResults/loadResults for Spectra etc

### DIFF
--- a/R/PlainTextParam.R
+++ b/R/PlainTextParam.R
@@ -152,6 +152,8 @@ setMethod("storeResults",
                          recursive = TRUE,
                          showWarnings = TRUE)
               .store_msexperiment(x = object, path = param@path)
+              ## call export of individual other objects (not MsExperiment data)
+              storeResults(spectra(object), param)
           }
 )
 
@@ -188,6 +190,40 @@ setMethod("loadResults",
               res
           }
 )
+
+setMethod("storeResults", signature(object = "Spectra",
+                                    param = "PlainTextParam"),
+          function(object, param) {
+              ## Check if there is a method to store the backend. Throw an
+              ## error if not.
+              if (!existsMethod("storeResults", c(class(object@backend)[1L],
+                                                  "PlainTextParam")))
+                  stop("Can not store a 'Spectra' object with backend '",
+                       class(object@backend)[1L], "'")
+              ## - Call storeResults on @backend.
+              ## - save @processingQueue -> json (use previously implemented
+              ##   function).
+              ## Save the rest of the slots to a txt file, spectra_slots.txt
+              ## - save @processingQueueVariables, separated by "|"
+              ## - save @processingChunkSize.
+              ## - save the class of the backend (to allow calling import on
+              ##   the specific class.
+          })
+
+setMethod("storeResults", signature(object = "MsBackendMzR",
+                                    param = "PlainTextParam"),
+          function(object, param) {
+              ## save the @spectraData -> text file (tab delimited table).
+})
+
+setMethod("loadResults", signature(object = "MsBackendMzR",
+                                    param = "PlainTextParam"),
+          function(object, param, spectraPath = character()) {
+              ## load spectraData data.frame
+              ## replace the absolute paths in "dataStorage" with
+              ## spectraPath if that is defined.
+})
+
 
 #' @noRd
 .store_msexperiment <- function(x, path = tempdir()) {

--- a/tests/testthat/test_PlainTextParam.R
+++ b/tests/testthat/test_PlainTextParam.R
@@ -1,20 +1,37 @@
 xmse_full <- loadXcmsData("xmse")
 
-test_that("storeResults,PlainTextParam,MsExperiment works", {
+test_that("storeResults,loadResults,PlainTextParam,MsExperiment works", {
     pth <- file.path(tempdir(), "test")
     param <- PlainTextParam(path = pth)
     param2 <- PlainTextParam()
     expect_false(is.null(param2))
     expect_error(new("PlainTextParam", path = c(tempdir(), tempdir())))
-    mse <- filterMzRange(mse, c(200, 500))
-    storeResults(mse, param = param)
+    tmp <- filterMzRange(mse, c(200, 500))
+    storeResults(tmp, param = param)
     expect_true(dir.exists(pth))
     expect_true(file.exists(file.path(param@path, "sample_data.txt")))
     expect_true(file.exists(file.path(param@path, "spectra_files.txt")))
     expect_true(file.exists(file.path(param@path, "spectra_processing_queue.json")))
+    ## Loading data again
+    load_mse <- loadResults(object = MsExperiment(), param)
+    expect_true(inherits(load_mse, "MsExperiment"))
+    expect_equal(sampleData(tmp), sampleData(load_mse))
+    a <- spectra(tmp)
+    b <- spectra(load_mse)
+    ## processingQueue can not be identical because of FUN, which is a function
+    ## expect_equal(a@processingQueue, b@processingQueue)
+    expect_equal(a@processingQueue[[1L]]@ARGS, b@processingQueue[[1L]]@ARGS)
+    expect_equal(rtime(a), rtime(b))
+    expect_equal(intensity(a), intensity(b))
+    expect_equal(mz(a), mz(b))
+    ## NOTE: if we in addition filter or subset the Spectra we can't store
+    ## properly to a txt file! Would need to store information on the data
+    ## subset too.
+    tmp <- filterRt(tmp, c(3000, 3500))
+
 })
 
-test_that("storeResults,PlainTextParam,XcmsExperiment works", {
+test_that("storeResults,loadResults,PlainTextParam,XcmsExperiment works", {
     pth = file.path(tempdir(), "test")
     param <- PlainTextParam(path = pth)
     param2 <- PlainTextParam()
@@ -38,12 +55,6 @@ test_that("storeResults,PlainTextParam,XcmsExperiment works", {
 
 test_that("loadResults, PlainTextParam works", {
     ## test for MsExperiment object only
-    pth = file.path(tempdir(), "test3")
-    param <- PlainTextParam(path = pth)
-    storeResults(mse, param = param)
-    load_mse <- loadResults(object = MsExperiment(), param)
-    expect_true(inherits(load_mse, "MsExperiment"))
-    expect_equal(mse, load_mse)
 
     ## test for XcmsExperiment object
     pth = file.path(tempdir(), "test4")
@@ -59,5 +70,3 @@ test_that("loadResults, PlainTextParam works", {
     expect_equal(xmse_full, load_xmse)
     # not sure how to check  for `spectraFilePath`
     })
-
-


### PR DESCRIPTION
Some thoughts on how to maybe implement the text import/export in a more future-proof (and modular) way.