### PR TITLE
Adding `chromPeaks` metadata to the `Spectra` output of `chromPeakSpectra()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.5.0
+Version: 4.5.1
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.5.1
+Version: 4.5.2
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -159,3 +159,4 @@ Collate:
     'writemztab.R'
     'xcmsSource.R'
     'zzz.R'
+    

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,15 @@
-# xcms 4.3
+# xcms 4.5
+
+## Changes in version 4.5.1
+
+- Small update to `featureSpectra()` and `chromPeakSpectra()` to allow addition
+  of `chromPeaks()` and `featuresDefinitions()` columns to be added to the
+  `Spectra` output. 
+- Tidied the `xcms` vignette, to order the filtering of features and remove 
+  the outdated normalisation paragraph.In depth discussion on this subject can 
+  be found on `metabonaut`. 
+
+# 4.3
 
 ## Changes in version 4.3.4
 
@@ -6,8 +17,6 @@
   of the chromPeaks matched with Lamas. 
 - Small fix to the .yml file for the github actions, so they do not crash on 
   warnings.
-
-
 
 ## Changes in version 4.3.3
 

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -417,15 +417,13 @@ setGeneric("chromPeakData<-", function(object, value)
 #' spectra for one chromatographic peak (or a `Spectra` of length 0 if no
 #' spectrum was found for the respective chromatographic peak).
 #'
-#' Parameters `addColumnsChromPeaks` allow the user to add specific metadata
+#' Parameters `chromPeakColumns` allow the user to add specific metadata
 #' columns from the chromatographic peaks (`chromPeaks`) to the returned
 #' spectra object. This can be useful to retain information such as retention
 #' time (`rt`), m/z (`mz`). The columns will be named as they is written in the
-#' `chromPeaks` object with a prefix that is defined by the parameter
-#' `addColumnsChromPeaksPrefix`. The *peak ID* (i.e., the row name of the
-#' peak in the `chromPeaks` matrix) is always added to the spectra object as
-#' metadata column `paste0(addColumnsChromPeaksPrefix,id)`, by default it will
-#' be `"chrom_peak_id"`.
+#' `chromPeaks` object with the prefix `"chrom_peak_"`. The *peak ID*
+#' (i.e., the row name of the peak in the `chromPeaks` matrix) is always added
+#' to the spectra object as a metadata column named `"chrom_peak_id"`.
 #'
 #' See also the *LC-MS/MS data analysis* vignette for more details and examples.
 #'
@@ -460,15 +458,10 @@ setGeneric("chromPeakData<-", function(object, value)
 #' @param return.type `character(1)` defining the type of result object that
 #'     should be returned.
 #'
-#' @param addColumnsChromPeaks `character` vector with the names of the columns
+#' @param chromPeakColumns `character` vector with the names of the columns
 #'    from `chromPeaks` that should be added to the returned spectra object.
 #'    The columns will be named as they are written in the `chromPeaks` object
-#'    with a prefix that is defined by the parameter
-#'    `addColumnsChromPeaksPrefix`. Defaults to `c("mz", "rt")`.
-#'
-#' @param addColumnsChromPeaksPrefix `character(1)` defining the prefix that
-#'    should be used for the columns from `chromPeaks` that are added to the
-#'    returned spectra object. Defaults to `"chrom_peak_"`.
+#'    with a prefix `"chrom_peak_"`. Defaults to `c("mz", "rt")`.
 #'
 #' @param BPPARAM parallel processing setup. Defaults to [bpparam()].
 #'
@@ -517,7 +510,7 @@ setGeneric("chromPeakData<-", function(object, value)
 #' ms2_sps <- chromPeakSpectra(dda)
 #' ms2_sps
 #'
-#' ## spectra variable *peak_id* contain the row names of the peaks in the
+#' ## spectra variable *chrom_peak_id* contain the row names of the peaks in the
 #' ## chromPeak matrix and allow thus to map chromatographic peaks to the
 #' ## returned MS2 spectra
 #' ms2_sps$chrom_peak_id
@@ -817,23 +810,20 @@ setGeneric("featureDefinitions<-", function(object, value)
 #' spectra per feature).
 #'
 #' The information from `featureDefinitions` for each feature can be included
-#' in the returned [Spectra()] object using the `addColumnsFeatures` parameter.
+#' in the returned [Spectra()] object using the `featureColumns` parameter.
 #' This is useful for retaining details such as the median retention time (`rtmed`)
 #' or median m/z (`mzmed`). The columns will retain their names as specified
-#' in the `featureDefinitions` object, prefixed by the value of the
-#' `addColumnsFeaturesPrefix` parameter. Additionally, the *feature ID*
-#' (i.e., the row name of the feature in the `featureDefinitions` data.frame)
-#' is always added as a metadata column with the name
-#' `paste0(addColumnsFeaturesPrefix, "id")`, which defaults to `"feature_id"`.
+#' in the `featureDefinitions` object, prefixed by `"feature_"`
+#' (e.g., `"feature_mzmed"`). Additionally, the *feature ID* (i.e., the row
+#' name of the feature in the `featureDefinitions` data.frame) is always added
+#' as a metadata column named `"feature_id"`.
 #'
 #' See also [chromPeakSpectra()], as it supports a similar parameter for
 #' including columns from the chromatographic peaks in the returned spectra object.
 #' These parameters can be used in combination to include information from both
 #' the chromatographic peaks and the features in the returned [Spectra()].
 #' The *peak ID* (i.e., the row name of the peak in the `chromPeaks` matrix)
-#' is added as a metadata column with the name
-#' `paste0(addColumnsChromPeaksPrefix, "id")`, which defaults to
-#' `"chrom_peak_id"`.
+#' is added as a metadata column named `"chrom_peak_id"`.
 #'
 #' @param object [XcmsExperiment] or [XCMSnExp] object with feature defitions.
 #'
@@ -846,15 +836,11 @@ setGeneric("featureDefinitions<-", function(object, value)
 #'     `featureDefinitions(x)`). This parameter overrides `skipFilled` and is
 #'     only supported for `return.type` being either `"Spectra"` or `"List"`.
 #'
-#' @param addColumnsFeatures `character` vector with the names of the columns
+#' @param featureColumns `character` vector with the names of the columns
 #'     from `featureDefinitions` that should be added to the returned spectra
 #'     object. The columns will be named as they are written in the
-#'    `featureDefinitions` object with a prefix that is defined by the parameter
-#'    `addColumnsFeaturesPrefix`. Defaults to `c("mzmed", "rtmed")`.
-#'
-#' @param addColumnsFeaturesPrefix `character(1)` defining the prefix that
-#'     should be used for the columns from `featureDefinitions` that are added
-#'     to the returned spectra object. Defaults to `"feature_"`.
+#'    `featureDefinitions` object with the prefix `"feature_`.
+#'     Defaults to `c("mzmed", "rtmed")`.
 #'
 #' @param ... additional arguments to be passed along to [chromPeakSpectra()],
 #'     such as `method`.
@@ -866,7 +852,7 @@ setGeneric("featureDefinitions<-", function(object, value)
 #' the order and the length matches parameter `features` (or if no `features`
 #' is defined the order of the features in `featureDefinitions(object)`).
 #'
-#' Spectra variables `"peak_id"` and `"feature_id"` define to which
+#' Spectra variables `"chrom_peak_id"` and `"feature_id"` define to which
 #' chromatographic peak or feature each individual spectrum is associated
 #' with.
 #'

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -411,14 +411,21 @@ setGeneric("chromPeakData<-", function(object, value)
 #'
 #' Parameter `return.type` allows to specify the *type* of the result object.
 #' With `return.type = "Spectra"` (the default) a [Spectra] object with all
-#' matching spectra is returned. The spectra variable `"peak_id"` of the
-#' returned `Spectra` contains the ID of the chromatographic peak (i.e., the
-#' rowname of the peak in the `chromPeaks` matrix) for each spectrum.
-#' With `return.type = "Spectra"` a `List` of `Spectra` is returned. The
-#' length of the list is equal to the number of rows of `chromPeaks`. Each
-#' element of the list contains thus a `Spectra` with all spectra for one
-#' chromatographic peak (or a `Spectra` of length 0 if no spectrum was found
-#' for the respective chromatographic peak).
+#' matching spectra is returned. With `return.type = "Spectra"` a `List` of
+#' `Spectra` is returned. The length of the list is equal to the number of rows
+#' of `chromPeaks`. Each element of the list contains thus a `Spectra` with all
+#' spectra for one chromatographic peak (or a `Spectra` of length 0 if no
+#' spectrum was found for the respective chromatographic peak).
+#'
+#' Parameters `addColumnsChromPeaks` allow the user to add specific metadata
+#' columns from the chromatographic peaks (`chromPeaks`) to the returned
+#' spectra object. This can be useful to retain information such as retention
+#' time (`rt`), m/z (`mz`). The columns will be named as they is written in the
+#' `chromPeaks` object with a prefix that is defined by the parameter
+#' `addColumnsChromPeaksPrefix`. The *peak ID* (i.e., the row name of the
+#' peak in the `chromPeaks` matrix) is always added to the spectra object as
+#' metadata column `paste0(addColumnsChromPeaksPrefix,id)`, by default it will
+#' be `"chrom_peak_id"`.
 #'
 #' See also the *LC-MS/MS data analysis* vignette for more details and examples.
 #'
@@ -452,6 +459,16 @@ setGeneric("chromPeakData<-", function(object, value)
 #'
 #' @param return.type `character(1)` defining the type of result object that
 #'     should be returned.
+#'
+#' @param addColumnsChromPeaks `character` vector with the names of the columns
+#'    from `chromPeaks` that should be added to the returned spectra object.
+#'    The columns will be named as they are written in the `chromPeaks` object
+#'    with a prefix that is defined by the parameter
+#'    `addColumnsChromPeaksPrefix`. Defaults to `c("mz", "rt")`.
+#'
+#' @param addColumnsChromPeaksPrefix `character(1)` defining the prefix that
+#'    should be used for the columns from `chromPeaks` that are added to the
+#'    returned spectra object. Defaults to `"chrom_peak_"`.
 #'
 #' @param BPPARAM parallel processing setup. Defaults to [bpparam()].
 #'
@@ -503,7 +520,7 @@ setGeneric("chromPeakData<-", function(object, value)
 #' ## spectra variable *peak_id* contain the row names of the peaks in the
 #' ## chromPeak matrix and allow thus to map chromatographic peaks to the
 #' ## returned MS2 spectra
-#' ms2_sps$peak_id
+#' ms2_sps$chrom_peak_id
 #' chromPeaks(dda)
 #'
 #' ## Alternatively, return the result as a List of Spectra objects. This list
@@ -799,10 +816,24 @@ setGeneric("featureDefinitions<-", function(object, value)
 #' spectrum **per chromatographic peak** will be returned (hence multiple
 #' spectra per feature).
 #'
-#' The ID of each chromatographic peak (i.e. its row name in `chromPeaks`)
-#' and each feature (i.e., its row name in `featureDefinitions`) are
-#' available in the returned [Spectra()] with spectra variables `"peak_id"`
-#' and `"feature_id"`, respectively.
+#' The information from `featureDefinitions` for each feature can be included
+#' in the returned [Spectra()] object using the `addColumnsFeatures` parameter.
+#' This is useful for retaining details such as the median retention time (`rtmed`)
+#' or median m/z (`mzmed`). The columns will retain their names as specified
+#' in the `featureDefinitions` object, prefixed by the value of the
+#' `addColumnsFeaturesPrefix` parameter. Additionally, the *feature ID*
+#' (i.e., the row name of the feature in the `featureDefinitions` data.frame)
+#' is always added as a metadata column with the name
+#' `paste0(addColumnsFeaturesPrefix, "id")`, which defaults to `"feature_id"`.
+#'
+#' See also [chromPeakSpectra()], as it supports a similar parameter for
+#' including columns from the chromatographic peaks in the returned spectra object.
+#' These parameters can be used in combination to include information from both
+#' the chromatographic peaks and the features in the returned [Spectra()].
+#' The *peak ID* (i.e., the row name of the peak in the `chromPeaks` matrix)
+#' is added as a metadata column with the name
+#' `paste0(addColumnsChromPeaksPrefix, "id")`, which defaults to
+#' `"chrom_peak_id"`.
 #'
 #' @param object [XcmsExperiment] or [XCMSnExp] object with feature defitions.
 #'
@@ -814,6 +845,16 @@ setGeneric("featureDefinitions<-", function(object, value)
 #'     than `nrow(featureDefinitions(x))` or their index in
 #'     `featureDefinitions(x)`). This parameter overrides `skipFilled` and is
 #'     only supported for `return.type` being either `"Spectra"` or `"List"`.
+#'
+#' @param addColumnsFeatures `character` vector with the names of the columns
+#'     from `featureDefinitions` that should be added to the returned spectra
+#'     object. The columns will be named as they are written in the
+#'    `featureDefinitions` object with a prefix that is defined by the parameter
+#'    `addColumnsFeaturesPrefix`. Defaults to `c("mzmed", "rtmed")`.
+#'
+#' @param addColumnsFeaturesPrefix `character(1)` defining the prefix that
+#'     should be used for the columns from `featureDefinitions` that are added
+#'     to the returned spectra object. Defaults to `"feature_"`.
 #'
 #' @param ... additional arguments to be passed along to [chromPeakSpectra()],
 #'     such as `method`.

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -417,10 +417,10 @@ setGeneric("chromPeakData<-", function(object, value)
 #' spectra for one chromatographic peak (or a `Spectra` of length 0 if no
 #' spectrum was found for the respective chromatographic peak).
 #'
-#' Parameters `chromPeakColumns` allow the user to add specific metadata
+#' Parameter `chromPeakColumns` allows the user to add specific metadata
 #' columns from the chromatographic peaks (`chromPeaks`) to the returned
-#' spectra object. This can be useful to retain information such as retention
-#' time (`rt`), m/z (`mz`). The columns will be named as they is written in the
+#' spectra object. This can be useful to keep information such as retention
+#' time (`rt`), m/z (`mz`). The columns will be named as they are written in the
 #' `chromPeaks` object with the prefix `"chrom_peak_"`. The *peak ID*
 #' (i.e., the row name of the peak in the `chromPeaks` matrix) is always added
 #' to the spectra object as a metadata column named `"chrom_peak_id"`.
@@ -811,7 +811,7 @@ setGeneric("featureDefinitions<-", function(object, value)
 #'
 #' The information from `featureDefinitions` for each feature can be included
 #' in the returned [Spectra()] object using the `featureColumns` parameter.
-#' This is useful for retaining details such as the median retention time (`rtmed`)
+#' This is useful for keeping details such as the median retention time (`rtmed`)
 #' or median m/z (`mzmed`). The columns will retain their names as specified
 #' in the `featureDefinitions` object, prefixed by `"feature_"`
 #' (e.g., `"feature_mzmed"`). Additionally, the *feature ID* (i.e., the row

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -831,6 +831,8 @@
             ids <- rep(rownames(pk), lengths(idx))
             res <- sp[unlist(idx)]
             res$peak_id <- ids
+            info <- pk[res$peak_id, peaksInfo]
+            colnames(info) <- paste("peak_", peaksInfo, sep = "")
             res2@backend@spectraData <- cbind(res2@backend@spectraData, info)
             res
         },

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -797,7 +797,7 @@
                                    chromPeakColumns = c("rt", "mz"),
                                    BPPARAM = bpparam()) {
     method <- match.arg(method)
-    if (!chromPeakColumns %in% colnames(.chromPeaks(x)))
+    if (!all(chromPeakColumns %in% colnames(.chromPeaks(x))))
         stop("One or more of the columns in 'chromPeakColumns' are not ",
              "available in the 'chromPeaks' data.")
     pks <- .chromPeaks(x)[, union(c("mz", "mzmin", "mzmax", "rt",

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -797,8 +797,12 @@
                                    chromPeakColumns = c("rt", "mz"),
                                    BPPARAM = bpparam()) {
     method <- match.arg(method)
-    pks <- .chromPeaks(x)[, c("mz", "mzmin", "mzmax", "rt",
-                              "rtmin", "rtmax", "maxo", "sample")]
+    if (!chromPeakColumns %in% colnames(.chromPeaks(x)))
+        stop("One or more of the columns in 'chromPeakColumns' are not ",
+             "available in the 'chromPeaks' data.")
+    pks <- .chromPeaks(x)[, union(c("mz", "mzmin", "mzmax", "rt",
+                              "rtmin", "rtmax", "maxo", "sample"),
+                              chromPeakColumns)]
     if (ppm != 0)
         expandMz <- expandMz + pks[, "mz"] * ppm / 1e6
     if (expandMz[1L] != 0) {

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -794,8 +794,7 @@
                                    msLevel = 2L, expandRt = 0, expandMz = 0,
                                    ppm = 0, skipFilled = FALSE,
                                    peaks = integer(),
-                                   addColumnsChromPeaks = c("rt", "mz"),
-                                   addColumnsChromPeaksPrefix = "chrom_peak_",
+                                   chromPeakColumns = c("rt", "mz"),
                                    BPPARAM = bpparam()) {
     method <- match.arg(method)
     pks <- .chromPeaks(x)[, c("mz", "mzmin", "mzmax", "rt",
@@ -821,8 +820,7 @@
     res <- bpmapply(
         split.data.frame(pks, f),
         split(spectra(x), factor(fromFile(x), levels = levels(f))),
-        FUN = function(pk, sp, msLevel, method, addColumnsChromPeaks,
-                       addColumnsChromPeaksPrefix) {
+        FUN = function(pk, sp, msLevel, method, chromPeakColumns) {
             sp <- filterMsLevel(sp, msLevel)
             idx <- switch(
                 method,
@@ -833,17 +831,14 @@
                 largest_bpi = .spectra_index_list_largest_bpi(sp, pk, msLevel))
             ids <- rep(rownames(pk), lengths(idx))
             res <- sp[unlist(idx)]
-            pk_data <- as.data.frame(pk[ids, addColumnsChromPeaks,
-                                        drop = FALSE])
+            pk_data <- as.data.frame(pk[ids, chromPeakColumns, drop = FALSE])
             pk_data$id <- ids
-            colnames(pk_data) <- paste0(addColumnsChromPeaksPrefix,
-                                          colnames(pk_data))
+            colnames(pk_data) <- paste0("chrom_peak_", colnames(pk_data))
             res <- .add_spectra_data(res, pk_data)
             res
         },
         MoreArgs = list(msLevel = msLevel, method = method,
-                        addColumnsChromPeaks = addColumnsChromPeaks,
-                        addColumnsChromPeaksPrefix = addColumnsChromPeaksPrefix),
+                        chromPeakColumns = chromPeakColumns),
         BPPARAM = BPPARAM)
     Spectra:::.concatenate_spectra(res)
 }

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -793,7 +793,8 @@
                                                  "largest_bpi"),
                                    msLevel = 2L, expandRt = 0, expandMz = 0,
                                    ppm = 0, skipFilled = FALSE,
-                                   peaks = integer(), BPPARAM = bpparam()) {
+                                   peaks = integer(), peaksInfo = c("rt", "mz"),
+                                   BPPARAM = bpparam()) {
     method <- match.arg(method)
     pks <- .chromPeaks(x)[, c("mz", "mzmin", "mzmax", "rt",
                               "rtmin", "rtmax", "maxo", "sample")]
@@ -830,6 +831,7 @@
             ids <- rep(rownames(pk), lengths(idx))
             res <- sp[unlist(idx)]
             res$peak_id <- ids
+            res2@backend@spectraData <- cbind(res2@backend@spectraData, info)
             res
         },
         MoreArgs = list(msLevel = msLevel, method = method),

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -833,7 +833,7 @@
             res$peak_id <- ids
             info <- pk[res$peak_id, peaksInfo]
             colnames(info) <- paste("peak_", peaksInfo, sep = "")
-            res2@backend@spectraData <- cbind(res2@backend@spectraData, info)
+            res@backend@spectraData <- cbind(res@backend@spectraData, info)
             res
         },
         MoreArgs = list(msLevel = msLevel, method = method),

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -823,7 +823,7 @@
         split(spectra(x), factor(fromFile(x), levels = levels(f))),
         FUN = function(pk, sp, msLevel, method, addColumnsChromPeaks,
                        addColumnsChromPeaksPrefix) {
-            sp <- Spectra::filterMsLevel(sp, msLevel)
+            sp <- filterMsLevel(sp, msLevel)
             idx <- switch(
                 method,
                 all = .spectra_index_list(sp, pk, msLevel),
@@ -833,8 +833,9 @@
                 largest_bpi = .spectra_index_list_largest_bpi(sp, pk, msLevel))
             ids <- rep(rownames(pk), lengths(idx))
             res <- sp[unlist(idx)]
-            pk_data <- pk[ids, addColumnsChromPeaks, drop = FALSE]
-            pk_data <- cbind(pk_data, id = ids)
+            pk_data <- as.data.frame(pk[ids, addColumnsChromPeaks,
+                                        drop = FALSE])
+            pk_data$id <- ids
             colnames(pk_data) <- paste0(addColumnsChromPeaksPrefix,
                                           colnames(pk_data))
             res <- .add_spectra_data(res, pk_data)

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1232,7 +1232,7 @@ setMethod(
     function(object, method = c("all", "closest_rt", "closest_mz",
                                 "largest_tic", "largest_bpi"),
              msLevel = 2L, expandRt = 0, expandMz = 0, ppm = 0,
-             skipFilled = FALSE, peaks = character(), peaksInfo = c("rt", "mz")
+             skipFilled = FALSE, peaks = character(), peaksInfo = c("rt", "mz"),
              return.type = c("Spectra", "List"), BPPARAM = bpparam()) {
         if (hasAdjustedRtime(object))
             object <- applyAdjustedRtime(object)

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1804,7 +1804,7 @@ setMethod(
             object, msLevel = msLevel, expandRt = expandRt,
             expandMz = expandMz, ppm = ppm, skipFilled = skipFilled,
             peaks = unique(pindex),
-            addColumnsChromPeaksPrefix = addColumnsChromPeaksPrefix)
+            addColumnsChromPeaksPrefix = addColumnsChromPeaksPrefix, ...)
         col <- paste0(addColumnsChromPeaksPrefix, "id")
         mtch <- as.matrix(
             findMatches(sps[[col]], rownames(.chromPeaks(object))[pindex]))

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1782,6 +1782,9 @@ setMethod(
         if (!hasFeatures(object))
             stop("No feature definitions present. Please run ",
                  "'groupChromPeaks' first.")
+        if (!featureColumns %in% colnames(featureDefinitions(object)))
+            stop("One or more of the requested 'featureColumns' are not ",
+                 "present in the feature definitions.")
         if (hasAdjustedRtime(object))
             object <- applyAdjustedRtime(object)
         features_all <- rownames(featureDefinitions(object))

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1232,7 +1232,9 @@ setMethod(
     function(object, method = c("all", "closest_rt", "closest_mz",
                                 "largest_tic", "largest_bpi"),
              msLevel = 2L, expandRt = 0, expandMz = 0, ppm = 0,
-             skipFilled = FALSE, peaks = character(), peaksInfo = c("rt", "mz"),
+             skipFilled = FALSE, peaks = character(),
+             addColumnsChromPeaks = c("rt", "mz"),
+             addColumnsChromPeaksPrefix = "chrom_peak_",
              return.type = c("Spectra", "List"), BPPARAM = bpparam()) {
         if (hasAdjustedRtime(object))
             object <- applyAdjustedRtime(object)
@@ -1248,14 +1250,19 @@ setMethod(
         else pkidx <- integer()
         res <- .mse_spectra_for_peaks(object, method, msLevel, expandRt,
                                       expandMz, ppm, skipFilled, pkidx,
-                                      peaksInfo, BPPARAM)
+                                      addColumnsChromPeaks,
+                                      addColumnsChromPeaksPrefix,
+                                      BPPARAM)
         if (!length(pkidx))
             peaks <- rownames(.chromPeaks(object))
         else peaks <- rownames(.chromPeaks(object))[pkidx]
-        if (return.type == "Spectra")
-            res <- res[as.matrix(findMatches(peaks, res$peak_id))[, 2L]]
-        else
-            as(split(res, factor(res$peak_id, levels = peaks)), "List")
+        if (return.type == "Spectra") {
+            col <- paste0(addColumnsChromPeaksPrefix, "id")
+            res <- res[as.matrix(findMatches(peaks, res[[col]]))[, 2L]]
+        } else {
+            col <- paste0(addColumnsChromPeaksPrefix, "id")
+            as(split(res, factor(res[[col]], levels = peaks)), "List")
+        }
     })
 
 #' @rdname reconstructChromPeakSpectra

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1782,7 +1782,7 @@ setMethod(
         if (!hasFeatures(object))
             stop("No feature definitions present. Please run ",
                  "'groupChromPeaks' first.")
-        if (!featureColumns %in% colnames(featureDefinitions(object)))
+        if (!all(featureColumns %in% colnames(featureDefinitions(object))))
             stop("One or more of the requested 'featureColumns' are not ",
                  "present in the feature definitions.")
         if (hasAdjustedRtime(object))

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -515,6 +515,10 @@
 #'     indicating the identified chromatographic peaks. Only a single color
 #'     is supported. Defaults to `peakCol = "#ff000060".
 #'
+#' @param peaksInfo For `chromPeakSpectra`: `character`  vector of additional
+#'    information from `chromPeaks()` to be added to the spectra object. The
+#'    columns names will be appended with "peaks_".
+#'
 #' @param ppm For `chromPeaks` and `featureDefinitions`: optional `numeric(1)`
 #'     specifying the ppm by which the m/z range (defined by `mz` should be
 #'     extended. For a value of `ppm = 10`, all peaks within `mz[1] - ppm / 1e6`
@@ -1228,7 +1232,7 @@ setMethod(
     function(object, method = c("all", "closest_rt", "closest_mz",
                                 "largest_tic", "largest_bpi"),
              msLevel = 2L, expandRt = 0, expandMz = 0, ppm = 0,
-             skipFilled = FALSE, peaks = character(),
+             skipFilled = FALSE, peaks = character(), peaksInfo = c("rt", "mz")
              return.type = c("Spectra", "List"), BPPARAM = bpparam()) {
         if (hasAdjustedRtime(object))
             object <- applyAdjustedRtime(object)
@@ -1244,7 +1248,7 @@ setMethod(
         else pkidx <- integer()
         res <- .mse_spectra_for_peaks(object, method, msLevel, expandRt,
                                       expandMz, ppm, skipFilled, pkidx,
-                                      BPPARAM)
+                                      peaksInfo, BPPARAM)
         if (!length(pkidx))
             peaks <- rownames(.chromPeaks(object))
         else peaks <- rownames(.chromPeaks(object))[pkidx]

--- a/R/do_adjustRtime-functions.R
+++ b/R/do_adjustRtime-functions.R
@@ -874,7 +874,7 @@ NULL
                       resid_ratio = 3,
                       zero_weight = 10,
                       bs = "tp"){
-    rt_map <- rt_map[order(rt_map$obs), ]
+    rt_map <- rt_map[order(rt_map$obs), c("ref", "obs")]
     # add first row of c(0,0) to set a fix timepoint.
     rt_map <- rbind(c(0,0), rt_map)
     weights <- rep(1, nrow(rt_map))

--- a/man/XcmsExperiment.Rd
+++ b/man/XcmsExperiment.Rd
@@ -396,10 +396,6 @@ also parameter \code{type} below for additional information.}
 \item{keepFeatures}{for most subsetting functions (\code{[}, \code{filterFile}):
 \code{logical(1)}: wheter eventually present feature definitions should
 be retained in the returned (filtered) object.}
-
-\item{peaksInfo}{For \code{chromPeakSpectra}: \code{character}  vector of additional
-information from \code{chromPeaks()} to be added to the spectra object. The
-columns names will be appended with "peaks_".}
 }
 \description{
 The \code{XcmsExperiment} is a data container for \code{xcms} preprocessing results

--- a/man/XcmsExperiment.Rd
+++ b/man/XcmsExperiment.Rd
@@ -396,6 +396,10 @@ also parameter \code{type} below for additional information.}
 \item{keepFeatures}{for most subsetting functions (\code{[}, \code{filterFile}):
 \code{logical(1)}: wheter eventually present feature definitions should
 be retained in the returned (filtered) object.}
+
+\item{peaksInfo}{For \code{chromPeakSpectra}: \code{character}  vector of additional
+information from \code{chromPeaks()} to be added to the spectra object. The
+columns names will be appended with "peaks_".}
 }
 \description{
 The \code{XcmsExperiment} is a data container for \code{xcms} preprocessing results

--- a/man/chromPeakSpectra.Rd
+++ b/man/chromPeakSpectra.Rd
@@ -18,6 +18,7 @@ chromPeakSpectra(object, ...)
   ppm = 0,
   skipFilled = FALSE,
   peaks = character(),
+  peaksInfo = c("rt", "mz"),
   return.type = c("Spectra", "List"),
   BPPARAM = bpparam()
 )

--- a/man/chromPeakSpectra.Rd
+++ b/man/chromPeakSpectra.Rd
@@ -18,7 +18,8 @@ chromPeakSpectra(object, ...)
   ppm = 0,
   skipFilled = FALSE,
   peaks = character(),
-  peaksInfo = c("rt", "mz"),
+  addColumnsChromPeaks = c("rt", "mz"),
+  addColumnsChromPeaksPrefix = "chrom_peak_",
   return.type = c("Spectra", "List"),
   BPPARAM = bpparam()
 )
@@ -65,6 +66,16 @@ subset of chromatographic peaks in \code{chromPeaks} for which spectra should
 be returned (providing either their ID, a logical vector same length
 than \code{nrow(chromPeaks(x))} or their index in \code{chromPeaks(x)}). This
 parameter overrides \code{skipFilled}.}
+
+\item{addColumnsChromPeaks}{\code{character} vector with the names of the columns
+from \code{chromPeaks} that should be added to the returned spectra object.
+The columns will be named as they are written in the \code{chromPeaks} object
+with a prefix that is defined by the parameter
+\code{addColumnsChromPeaksPrefix}. Defaults to \code{c("mz", "rt")}.}
+
+\item{addColumnsChromPeaksPrefix}{\code{character(1)} defining the prefix that
+should be used for the columns from \code{chromPeaks} that are added to the
+returned spectra object. Defaults to \code{"chrom_peak_"}.}
 
 \item{return.type}{\code{character(1)} defining the type of result object that
 should be returned.}
@@ -125,14 +136,21 @@ signal (\code{"maxo"}); only supported for \code{msLevel = 2L}.
 
 Parameter \code{return.type} allows to specify the \emph{type} of the result object.
 With \code{return.type = "Spectra"} (the default) a \link{Spectra} object with all
-matching spectra is returned. The spectra variable \code{"peak_id"} of the
-returned \code{Spectra} contains the ID of the chromatographic peak (i.e., the
-rowname of the peak in the \code{chromPeaks} matrix) for each spectrum.
-With \code{return.type = "Spectra"} a \code{List} of \code{Spectra} is returned. The
-length of the list is equal to the number of rows of \code{chromPeaks}. Each
-element of the list contains thus a \code{Spectra} with all spectra for one
-chromatographic peak (or a \code{Spectra} of length 0 if no spectrum was found
-for the respective chromatographic peak).
+matching spectra is returned. With \code{return.type = "Spectra"} a \code{List} of
+\code{Spectra} is returned. The length of the list is equal to the number of rows
+of \code{chromPeaks}. Each element of the list contains thus a \code{Spectra} with all
+spectra for one chromatographic peak (or a \code{Spectra} of length 0 if no
+spectrum was found for the respective chromatographic peak).
+
+Parameters \code{addColumnsChromPeaks} allow the user to add specific metadata
+columns from the chromatographic peaks (\code{chromPeaks}) to the returned
+spectra object. This can be useful to retain information such as retention
+time (\code{rt}), m/z (\code{mz}). The columns will be named as they is written in the
+\code{chromPeaks} object with a prefix that is defined by the parameter
+\code{addColumnsChromPeaksPrefix}. The \emph{peak ID} (i.e., the row name of the
+peak in the \code{chromPeaks} matrix) is always added to the spectra object as
+metadata column \code{paste0(addColumnsChromPeaksPrefix,id)}, by default it will
+be \code{"chrom_peak_id"}.
 
 See also the \emph{LC-MS/MS data analysis} vignette for more details and examples.
 }
@@ -155,7 +173,7 @@ ms2_sps
 ## spectra variable *peak_id* contain the row names of the peaks in the
 ## chromPeak matrix and allow thus to map chromatographic peaks to the
 ## returned MS2 spectra
-ms2_sps$peak_id
+ms2_sps$chrom_peak_id
 chromPeaks(dda)
 
 ## Alternatively, return the result as a List of Spectra objects. This list

--- a/man/chromPeakSpectra.Rd
+++ b/man/chromPeakSpectra.Rd
@@ -18,8 +18,7 @@ chromPeakSpectra(object, ...)
   ppm = 0,
   skipFilled = FALSE,
   peaks = character(),
-  addColumnsChromPeaks = c("rt", "mz"),
-  addColumnsChromPeaksPrefix = "chrom_peak_",
+  chromPeakColumns = c("rt", "mz"),
   return.type = c("Spectra", "List"),
   BPPARAM = bpparam()
 )
@@ -67,15 +66,10 @@ be returned (providing either their ID, a logical vector same length
 than \code{nrow(chromPeaks(x))} or their index in \code{chromPeaks(x)}). This
 parameter overrides \code{skipFilled}.}
 
-\item{addColumnsChromPeaks}{\code{character} vector with the names of the columns
+\item{chromPeakColumns}{\code{character} vector with the names of the columns
 from \code{chromPeaks} that should be added to the returned spectra object.
 The columns will be named as they are written in the \code{chromPeaks} object
-with a prefix that is defined by the parameter
-\code{addColumnsChromPeaksPrefix}. Defaults to \code{c("mz", "rt")}.}
-
-\item{addColumnsChromPeaksPrefix}{\code{character(1)} defining the prefix that
-should be used for the columns from \code{chromPeaks} that are added to the
-returned spectra object. Defaults to \code{"chrom_peak_"}.}
+with a prefix \code{"chrom_peak_"}. Defaults to \code{c("mz", "rt")}.}
 
 \item{return.type}{\code{character(1)} defining the type of result object that
 should be returned.}
@@ -142,15 +136,13 @@ of \code{chromPeaks}. Each element of the list contains thus a \code{Spectra} wi
 spectra for one chromatographic peak (or a \code{Spectra} of length 0 if no
 spectrum was found for the respective chromatographic peak).
 
-Parameters \code{addColumnsChromPeaks} allow the user to add specific metadata
+Parameters \code{chromPeakColumns} allow the user to add specific metadata
 columns from the chromatographic peaks (\code{chromPeaks}) to the returned
 spectra object. This can be useful to retain information such as retention
 time (\code{rt}), m/z (\code{mz}). The columns will be named as they is written in the
-\code{chromPeaks} object with a prefix that is defined by the parameter
-\code{addColumnsChromPeaksPrefix}. The \emph{peak ID} (i.e., the row name of the
-peak in the \code{chromPeaks} matrix) is always added to the spectra object as
-metadata column \code{paste0(addColumnsChromPeaksPrefix,id)}, by default it will
-be \code{"chrom_peak_id"}.
+\code{chromPeaks} object with the prefix \code{"chrom_peak_"}. The \emph{peak ID}
+(i.e., the row name of the peak in the \code{chromPeaks} matrix) is always added
+to the spectra object as a metadata column named \code{"chrom_peak_id"}.
 
 See also the \emph{LC-MS/MS data analysis} vignette for more details and examples.
 }
@@ -170,7 +162,7 @@ dda <- findChromPeaks(dda, CentWaveParam(peakwidth = c(5, 15),
 ms2_sps <- chromPeakSpectra(dda)
 ms2_sps
 
-## spectra variable *peak_id* contain the row names of the peaks in the
+## spectra variable *chrom_peak_id* contain the row names of the peaks in the
 ## chromPeak matrix and allow thus to map chromatographic peaks to the
 ## returned MS2 spectra
 ms2_sps$chrom_peak_id

--- a/man/chromPeakSpectra.Rd
+++ b/man/chromPeakSpectra.Rd
@@ -136,10 +136,10 @@ of \code{chromPeaks}. Each element of the list contains thus a \code{Spectra} wi
 spectra for one chromatographic peak (or a \code{Spectra} of length 0 if no
 spectrum was found for the respective chromatographic peak).
 
-Parameters \code{chromPeakColumns} allow the user to add specific metadata
+Parameter \code{chromPeakColumns} allows the user to add specific metadata
 columns from the chromatographic peaks (\code{chromPeaks}) to the returned
-spectra object. This can be useful to retain information such as retention
-time (\code{rt}), m/z (\code{mz}). The columns will be named as they is written in the
+spectra object. This can be useful to keep information such as retention
+time (\code{rt}), m/z (\code{mz}). The columns will be named as they are written in the
 \code{chromPeaks} object with the prefix \code{"chrom_peak_"}. The \emph{peak ID}
 (i.e., the row name of the peak in the \code{chromPeaks} matrix) is always added
 to the spectra object as a metadata column named \code{"chrom_peak_id"}.

--- a/man/featureSpectra.Rd
+++ b/man/featureSpectra.Rd
@@ -18,6 +18,9 @@ featureSpectra(object, ...)
   skipFilled = FALSE,
   return.type = c("Spectra", "List"),
   features = character(),
+  addColumnsFeatures = c("rtmed", "mzmed"),
+  addColumnsFeaturesPrefix = "feature_",
+  addColumnsChromPeaksPrefix = "chrom_peak_",
   ...
 )
 
@@ -63,6 +66,20 @@ be returned (providing either their ID, a logical vector same length
 than \code{nrow(featureDefinitions(x))} or their index in
 \code{featureDefinitions(x)}). This parameter overrides \code{skipFilled} and is
 only supported for \code{return.type} being either \code{"Spectra"} or \code{"List"}.}
+
+\item{addColumnsFeatures}{\code{character} vector with the names of the columns
+from \code{featureDefinitions} that should be added to the returned spectra
+object. The columns will be named as they are written in the
+\code{featureDefinitions} object with a prefix that is defined by the parameter
+\code{addColumnsFeaturesPrefix}. Defaults to \code{c("mzmed", "rtmed")}.}
+
+\item{addColumnsFeaturesPrefix}{\code{character(1)} defining the prefix that
+should be used for the columns from \code{featureDefinitions} that are added
+to the returned spectra object. Defaults to \code{"feature_"}.}
+
+\item{addColumnsChromPeaksPrefix}{\code{character(1)} defining the prefix that
+should be used for the columns from \code{chromPeaks} that are added to the
+returned spectra object. Defaults to \code{"chrom_peak_"}.}
 }
 \value{
 The function returns either a \code{\link[=Spectra]{Spectra()}} (for \code{return.type = "Spectra"})
@@ -96,10 +113,24 @@ feature are returned. With any other option for \code{method}, a single
 spectrum \strong{per chromatographic peak} will be returned (hence multiple
 spectra per feature).
 
-The ID of each chromatographic peak (i.e. its row name in \code{chromPeaks})
-and each feature (i.e., its row name in \code{featureDefinitions}) are
-available in the returned \code{\link[=Spectra]{Spectra()}} with spectra variables \code{"peak_id"}
-and \code{"feature_id"}, respectively.
+The information from \code{featureDefinitions} for each feature can be included
+in the returned \code{\link[=Spectra]{Spectra()}} object using the \code{addColumnsFeatures} parameter.
+This is useful for retaining details such as the median retention time (\code{rtmed})
+or median m/z (\code{mzmed}). The columns will retain their names as specified
+in the \code{featureDefinitions} object, prefixed by the value of the
+\code{addColumnsFeaturesPrefix} parameter. Additionally, the \emph{feature ID}
+(i.e., the row name of the feature in the \code{featureDefinitions} data.frame)
+is always added as a metadata column with the name
+\code{paste0(addColumnsFeaturesPrefix, "id")}, which defaults to \code{"feature_id"}.
+
+See also \code{\link[=chromPeakSpectra]{chromPeakSpectra()}}, as it supports a similar parameter for
+including columns from the chromatographic peaks in the returned spectra object.
+These parameters can be used in combination to include information from both
+the chromatographic peaks and the features in the returned \code{\link[=Spectra]{Spectra()}}.
+The \emph{peak ID} (i.e., the row name of the peak in the \code{chromPeaks} matrix)
+is added as a metadata column with the name
+\code{paste0(addColumnsChromPeaksPrefix, "id")}, which defaults to
+\code{"chrom_peak_id"}.
 }
 \author{
 Johannes Rainer

--- a/man/featureSpectra.Rd
+++ b/man/featureSpectra.Rd
@@ -18,9 +18,7 @@ featureSpectra(object, ...)
   skipFilled = FALSE,
   return.type = c("Spectra", "List"),
   features = character(),
-  addColumnsFeatures = c("rtmed", "mzmed"),
-  addColumnsFeaturesPrefix = "feature_",
-  addColumnsChromPeaksPrefix = "chrom_peak_",
+  featureColumns = c("rtmed", "mzmed"),
   ...
 )
 
@@ -67,19 +65,11 @@ than \code{nrow(featureDefinitions(x))} or their index in
 \code{featureDefinitions(x)}). This parameter overrides \code{skipFilled} and is
 only supported for \code{return.type} being either \code{"Spectra"} or \code{"List"}.}
 
-\item{addColumnsFeatures}{\code{character} vector with the names of the columns
+\item{featureColumns}{\code{character} vector with the names of the columns
 from \code{featureDefinitions} that should be added to the returned spectra
 object. The columns will be named as they are written in the
-\code{featureDefinitions} object with a prefix that is defined by the parameter
-\code{addColumnsFeaturesPrefix}. Defaults to \code{c("mzmed", "rtmed")}.}
-
-\item{addColumnsFeaturesPrefix}{\code{character(1)} defining the prefix that
-should be used for the columns from \code{featureDefinitions} that are added
-to the returned spectra object. Defaults to \code{"feature_"}.}
-
-\item{addColumnsChromPeaksPrefix}{\code{character(1)} defining the prefix that
-should be used for the columns from \code{chromPeaks} that are added to the
-returned spectra object. Defaults to \code{"chrom_peak_"}.}
+\code{featureDefinitions} object with the prefix \verb{"feature_}.
+Defaults to \code{c("mzmed", "rtmed")}.}
 }
 \value{
 The function returns either a \code{\link[=Spectra]{Spectra()}} (for \code{return.type = "Spectra"})
@@ -87,7 +77,7 @@ or a \code{List} of \code{Spectra} (for \code{return.type = "List"}). For the la
 the order and the length matches parameter \code{features} (or if no \code{features}
 is defined the order of the features in \code{featureDefinitions(object)}).
 
-Spectra variables \code{"peak_id"} and \code{"feature_id"} define to which
+Spectra variables \code{"chrom_peak_id"} and \code{"feature_id"} define to which
 chromatographic peak or feature each individual spectrum is associated
 with.
 }
@@ -114,23 +104,20 @@ spectrum \strong{per chromatographic peak} will be returned (hence multiple
 spectra per feature).
 
 The information from \code{featureDefinitions} for each feature can be included
-in the returned \code{\link[=Spectra]{Spectra()}} object using the \code{addColumnsFeatures} parameter.
+in the returned \code{\link[=Spectra]{Spectra()}} object using the \code{featureColumns} parameter.
 This is useful for retaining details such as the median retention time (\code{rtmed})
 or median m/z (\code{mzmed}). The columns will retain their names as specified
-in the \code{featureDefinitions} object, prefixed by the value of the
-\code{addColumnsFeaturesPrefix} parameter. Additionally, the \emph{feature ID}
-(i.e., the row name of the feature in the \code{featureDefinitions} data.frame)
-is always added as a metadata column with the name
-\code{paste0(addColumnsFeaturesPrefix, "id")}, which defaults to \code{"feature_id"}.
+in the \code{featureDefinitions} object, prefixed by \code{"feature_"}
+(e.g., \code{"feature_mzmed"}). Additionally, the \emph{feature ID} (i.e., the row
+name of the feature in the \code{featureDefinitions} data.frame) is always added
+as a metadata column named \code{"feature_id"}.
 
 See also \code{\link[=chromPeakSpectra]{chromPeakSpectra()}}, as it supports a similar parameter for
 including columns from the chromatographic peaks in the returned spectra object.
 These parameters can be used in combination to include information from both
 the chromatographic peaks and the features in the returned \code{\link[=Spectra]{Spectra()}}.
 The \emph{peak ID} (i.e., the row name of the peak in the \code{chromPeaks} matrix)
-is added as a metadata column with the name
-\code{paste0(addColumnsChromPeaksPrefix, "id")}, which defaults to
-\code{"chrom_peak_id"}.
+is added as a metadata column named \code{"chrom_peak_id"}.
 }
 \author{
 Johannes Rainer

--- a/man/featureSpectra.Rd
+++ b/man/featureSpectra.Rd
@@ -105,7 +105,7 @@ spectra per feature).
 
 The information from \code{featureDefinitions} for each feature can be included
 in the returned \code{\link[=Spectra]{Spectra()}} object using the \code{featureColumns} parameter.
-This is useful for retaining details such as the median retention time (\code{rtmed})
+This is useful for keeping details such as the median retention time (\code{rtmed})
 or median m/z (\code{mzmed}). The columns will retain their names as specified
 in the \code{featureDefinitions} object, prefixed by \code{"feature_"}
 (e.g., \code{"feature_mzmed"}). Additionally, the \emph{feature ID} (i.e., the row

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -939,6 +939,9 @@ test_that("chromPeakSpectra works", {
     expect_error(chromPeakSpectra(xmse, peaks = "other"), "out of bounds")
 
     pks <- c("CP242", "CP007", "CP123")
+
+    expect_error(chromPeakSpectra(xmse, peaks = pks,
+                                  chromPeakColumns = "other"), "not available")
     res <- chromPeakSpectra(xmse, peaks = pks)
     expect_s4_class(res, "Spectra")
     expect_equal(length(res), 0)
@@ -1081,6 +1084,8 @@ test_that("filterFeatureDefinitions works", {
 
 test_that("featureSpectra works", {
     expect_error(featureSpectra(xmse), "No feature definitions")
+    expect_error(featureSpectra(xmseg,
+                                  featureColumns = "other"), "not present")
     res_all <- featureSpectra(xmseg, msLevel = 1L)
     expect_s4_class(res_all, "Spectra")
     expect_true(all(rownames(featureDefinitions(xmseg)) %in%

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -912,22 +912,22 @@ test_that(".spectra_index_list_closest_mz works", {
 test_that(".mse_spectra_for_peaks works", {
     res <- .mse_spectra_for_peaks(xmse)
     expect_s4_class(res, "Spectra")
-    expect_true(any(spectraVariables(res) == "peak_id"))
+    expect_true(any(spectraVariables(res) == "chrom_peak_id"))
     expect_true(length(res) == 0)
 
     res <- .mse_spectra_for_peaks(xmse, msLevel = 1L, method = "closest_rt")
     expect_s4_class(res, "Spectra")
-    expect_true(any(spectraVariables(res) == "peak_id"))
+    expect_true(any(spectraVariables(res) == "chrom_peak_id"))
     expect_true(length(res) == nrow(chromPeaks(xmse)))
 
     res <- .mse_spectra_for_peaks(xmse, msLevel = 1L, method = "all",
                                   peaks = 220)
-    expect_true(all(res$peak_id == "CP220"))
+    expect_true(all(res$chrom_peak_id == "CP220"))
 
     ## Duplicates index?
     res <- .mse_spectra_for_peaks(xmse, msLevel = 1L, method = "closest_rt",
                                   peaks = c(3, 2, 3, 3, 1))
-    expect_equal(res$peak_id, c("CP003", "CP002", "CP003", "CP003", "CP001"))
+    expect_equal(res$chrom_peak_id, c("CP003", "CP002", "CP003", "CP003", "CP001"))
     expect_equal(rtime(res)[1], rtime(res)[3])
     expect_equal(mz(res)[1], mz(res)[3])
 })
@@ -948,32 +948,34 @@ test_that("chromPeakSpectra works", {
     expect_equal(names(res), pks)
     res <- chromPeakSpectra(xmse, peaks = pks, msLevel = 1L)
     expect_s4_class(res, "Spectra")
-    expect_equal(unique(res$peak_id), pks)
+    expect_equal(unique(res$chrom_peak_id), pks)
 
     res2 <- chromPeakSpectra(xmse, msLevel = 1L, method = "closest_rt")
     expect_equal(length(res2), nrow(chromPeaks(xmse)))
-    expect_equal(res2$peak_id, rownames(chromPeaks(xmse)))
+    expect_equal(res2$chrom_peak_id, rownames(chromPeaks(xmse)))
 
     res2 <- chromPeakSpectra(xmse, msLevel = 1L, method = "largest_tic",
                              peaks = pks)
     expect_equal(length(res2), length(pks))
-    expect_equal(res2$peak_id, pks)
-    ic <- split(ionCount(res), factor(res$peak_id, levels = pks))
+    expect_equal(res2$chrom_peak_id, pks)
+    ic <- split(ionCount(res), factor(res$chrom_peak_id, levels = pks))
     idx <- vapply(ic, which.max, integer(1))
-    expect_equal(rtime(res2[1L]), rtime(res[res$peak_id == pks[1L]])[idx[1L]])
-    expect_equal(rtime(res2[2L]), rtime(res[res$peak_id == pks[2L]])[idx[2L]])
-    expect_equal(rtime(res2[3L]), rtime(res[res$peak_id == pks[3L]])[idx[3L]])
+    expect_equal(rtime(res2[1L]), rtime(res[res$chrom_peak_id == pks[1L]])[idx[1L]])
+    expect_equal(rtime(res2[2L]), rtime(res[res$chrom_peak_id == pks[2L]])[idx[2L]])
+    expect_equal(rtime(res2[3L]), rtime(res[res$chrom_peak_id == pks[3L]])[idx[3L]])
 
     res2 <- chromPeakSpectra(xmse, msLevel = 1L, method = "largest_bpi",
                              peaks = pks, return.type = "List")
     expect_equal(length(res2), length(pks))
     expect_equal(names(res2), pks)
     expect_true(all(lengths(res2) == 1L))
-    bpi <- split(max(intensity(res)), factor(res$peak_id, levels = pks))
+    bpi <- split(max(intensity(res)), factor(res$chrom_peak_id, levels = pks))
     idx <- vapply(bpi, which.max, integer(1))
-    expect_equal(rtime(res2[[1L]]), rtime(res[res$peak_id == pks[1L]])[idx[1L]])
-    expect_equal(rtime(res2[[2L]]), rtime(res[res$peak_id == pks[2L]])[idx[2L]])
-    expect_equal(rtime(res2[[3L]]), rtime(res[res$peak_id == pks[3L]])[idx[3L]])
+    expect_equal(rtime(res2[[1L]]), rtime(res[res$chrom_peak_id == pks[1L]])[idx[1L]])
+    expect_equal(rtime(res2[[2L]]), rtime(res[res$chrom_peak_id == pks[2L]])[idx[2L]])
+    expect_equal(rtime(res2[[3L]]), rtime(res[res$chrom_peak_id == pks[3L]])[idx[3L]])
+    expect(all(c("chrom_peak_id", "chrom_peak_mz", "chrom_peak_rt") %in%
+               spectraVariables(res2)))
 
     ## DDA data
     fl <- system.file("TripleTOF-SWATH/PestMix1_DDA.mzML", package = "msdata")
@@ -1083,6 +1085,9 @@ test_that("featureSpectra works", {
     expect_s4_class(res_all, "Spectra")
     expect_true(all(rownames(featureDefinitions(xmseg)) %in%
                     res_all$feature_id))
+    expect_true(all(c("chrom_peak_rt", "chrom_peak_mz", "chrom_peak_id",
+                      "feature_rtmed", "feature_mzmed", "feature_id") %in%
+                   spectraVariables(res_all)))
 
     res_all <- featureSpectra(xmseg, msLevel = 1L, method = "closest_rt",
                               return.type = "List")

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -963,6 +963,8 @@ test_that("chromPeakSpectra works", {
     expect_equal(rtime(res2[1L]), rtime(res[res$chrom_peak_id == pks[1L]])[idx[1L]])
     expect_equal(rtime(res2[2L]), rtime(res[res$chrom_peak_id == pks[2L]])[idx[2L]])
     expect_equal(rtime(res2[3L]), rtime(res[res$chrom_peak_id == pks[3L]])[idx[3L]])
+    expect_true(all(c("chrom_peak_id", "chrom_peak_mz", "chrom_peak_rt") %in%
+                   spectraVariables(res2)))
 
     res2 <- chromPeakSpectra(xmse, msLevel = 1L, method = "largest_bpi",
                              peaks = pks, return.type = "List")
@@ -974,8 +976,6 @@ test_that("chromPeakSpectra works", {
     expect_equal(rtime(res2[[1L]]), rtime(res[res$chrom_peak_id == pks[1L]])[idx[1L]])
     expect_equal(rtime(res2[[2L]]), rtime(res[res$chrom_peak_id == pks[2L]])[idx[2L]])
     expect_equal(rtime(res2[[3L]]), rtime(res[res$chrom_peak_id == pks[3L]])[idx[3L]])
-    expect(all(c("chrom_peak_id", "chrom_peak_mz", "chrom_peak_rt") %in%
-               spectraVariables(res2)))
 
     ## DDA data
     fl <- system.file("TripleTOF-SWATH/PestMix1_DDA.mzML", package = "msdata")
@@ -1107,10 +1107,10 @@ test_that("featureSpectra works", {
     res_2 <- featureSpectra(xmseg, msLevel = 1L, features = c("FT03", "FT01"),
                             return.type = "List")
     expect_true(length(res[[1L]]) < length(res_2[[1L]]))
-    expect_true(all(res[[1L]]$peak_id %in% res_2[[1L]]$peak_id))
+    expect_true(all(res[[1L]]$chrom_peak_id %in% res_2[[1L]]$chrom_peak_id))
     expect_equal(unique(res[[1L]]$feature_id), unique(res_2[[1L]]$feature_id))
     expect_true(length(res[[2L]]) < length(res_2[[2L]]))
-    expect_true(all(res[[2L]]$peak_id %in% res_2[[2L]]$peak_id))
+    expect_true(all(res[[2L]]$chrom_peak_id %in% res_2[[2L]]$chrom_peak_id))
     expect_equal(unique(res[[2L]]$feature_id), unique(res_2[[2L]]$feature_id))
 })
 

--- a/vignettes/xcms-lcms-ms.Rmd
+++ b/vignettes/xcms-lcms-ms.Rmd
@@ -206,7 +206,7 @@ dda_spectra$chrom_peak_id
 ```
 
 Some information about the chromatographic peak can also be added to the 
-returned `Spectra` object using the `addChromPeaksColumns` parameter in 
+returned `Spectra` object using the `chrompeakColumns` parameter in 
 `chromPeakSpectra()`. By default, the m/z and retention time of the 
 chromatographic peak are added to the spectra metadata.
 

--- a/vignettes/xcms-lcms-ms.Rmd
+++ b/vignettes/xcms-lcms-ms.Rmd
@@ -197,12 +197,21 @@ specifying `msLevel = 1L` in the call above (e.g. to evaluate the full MS1
 signal at the peak's apex position).
 
 The returned `Spectra` contains also the reference to the respective
-chromatographic peak as additional *spectra variable* `"peak_id"` that contains
+chromatographic peak as additional *spectra variable* `"chrom_peak_id"` that contains
 the identifier for the chromatographic peak (i.e. its row name in the
-`chromPeaks` matrix).
+`chromPeaks` matrix). 
 
-```{r peak_id}
-dda_spectra$peak_id
+```{r chrom_peak_id}
+dda_spectra$chrom_peak_id
+```
+
+Some information about the chromatographic peak can also be added to the 
+returned `Spectra` object using the `addChromPeaksColumns` parameter in 
+`chromPeakSpectra()`. By default, the m/z and retention time of the 
+chromatographic peak are added to the spectra metadata.
+
+```{r chrom_peak_mz}
+dda_spectra$chrom_peak_mz
 ```
 
 Note also that with `return.type = "List"` a list parallel to the `chromPeaks`
@@ -231,7 +240,7 @@ chromatographic peak using the ID of the peak in the present data set.
 
 ```{r dda-ms2-get-ms2, message = FALSE}
 ex_id <- rownames(chromPeaks(dda_data, mz = ex_mz, ppm = 20))
-ex_spectra <- dda_spectra[dda_spectra$peak_id == ex_id]
+ex_spectra <- dda_spectra[dda_spectra$chrom_peak_id == ex_id]
 ex_spectra
 ```
 
@@ -248,7 +257,7 @@ generally the best approach or suggested for all types of data.
 ex_spectrum <- combineSpectra(ex_spectra, FUN = combinePeaks, ppm = 20,
                               peaks = "intersect", minProp = 0.8,
                               intensityFun = median, mzFun = median,
-                              f = ex_spectra$peak_id)
+                              f = ex_spectra$chrom_peak_id)
 ex_spectrum
 ```
 
@@ -769,7 +778,7 @@ match almost perfectly. Next we get the MS2 spectra for this peak.
 
 ```{r pro-dda-ms2}
 prochloraz_dda_spectra <- dda_spectra[
-    dda_spectra$peak_id == rownames(prochloraz_dda_peak)]
+    dda_spectra$chrom_peak_id == rownames(prochloraz_dda_peak)]
 prochloraz_dda_spectra
 ```
 
@@ -780,7 +789,7 @@ peaks. Next we combine them into a consensus spectrum.
 prochloraz_dda_spectrum <- combineSpectra(
     prochloraz_dda_spectra, FUN = combinePeaks, ppm = 20,
     peaks = "intersect", minProp = 0.8, intensityFun = median, mzFun = median,
-    f = prochloraz_dda_spectra$peak_id)
+    f = prochloraz_dda_spectra$chrom_peak_id)
 ```
 
 At last we load also the Prochloraz MS2 spectra (for different collision

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -1205,9 +1205,8 @@ f[f == "QC"] <- NA
 
 missing_filter <- PercentMissingFilter(threshold = 30,
                                        f = f)
-
 # Apply the filter to faakho object
-filtered_faakho <- filterFeatures(object = faahko,
+filtered_faahko <- filterFeatures(object = faahko,
                                   filter = missing_filter)
 
 # Apply the filter to res object

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -62,7 +62,10 @@ be applied to the older *MSnbase*-based workflows (xcms version 3). Additional
 documents and tutorials covering also other topics of untargeted metabolomics
 analysis are listed at the end of this document. There is also a [xcms
 tutorial](https://jorainer.github.io/xcmsTutorials) available with more examples
-and details.
+and details. 
+To get a complete overview of LCMS-MS analysis, an end-to-end workflow
+[Metabonaut website](https://rformassspectrometry.github.io/metabonaut/), which 
+integrate the *xcms* preprocessing steps with the downstream analysis, is available. 
 
 
 # Preprocessing of LC-MS data
@@ -1180,6 +1183,53 @@ defined above.  The `filter` argument can accommodate various types of input,
 each determining the specific type of quality assessment and filtering to be
 performed.
 
+The `PercentMissingFilter` allows to filter features based on the percentage of
+missing values for each feature. This function takes as an input the parameter
+`f` which is supposed to be a vector of length equal to the length of the object
+(i.e. number of samples) with the sample type for each. The function then
+computes the percentage of missing values per sample groups and filters
+features based on this. Features with a percent of missing values larger than
+the threshold in all sample groups will be removed. Another option is to base
+this quality assessment and filtering only on QC samples.
+
+Both examples are shown below:
+
+```{r}
+# To set up parameter `f` to filter only based on QC samples
+f <- sampleData(filtered_faakho)$sample_type
+f[f != "QC"] <- NA
+
+# To set up parameter `f` to filter per sample type excluding QC samples
+f <- sampleData(filtered_faakho)$sample_type
+f[f == "QC"] <- NA
+
+missing_filter <- PercentMissingFilter(threshold = 30,
+                                       f = f)
+
+# Apply the filter to faakho object
+filtered_faakho <- filterFeatures(object = filtered_faakho,
+                                  filter = missing_filter)
+
+# Apply the filter to res object
+missing_filter <- PercentMissingFilter(threshold = 30,
+                                       f = f)
+filtered_res <- filterFeatures(object = filtered_res,
+                               filter = missing_filter)
+```
+
+Here, no feature was removed, meaning that all the features had less than 30%
+of `NA` values in at least one of the sample type.
+
+Although not directly relevant to this experiment, the `BlankFlag` filter can be
+used to flag features based on the intensity relationship between blank and QC
+samples. More information can be found in the documentation of the filter:
+
+```{r}
+# Retrieve documentation for the main function and the specific filter.
+?filterFeatures
+?BlankFlag
+```
+
 The `RsdFilter` enable users to filter features based on their relative
 standard deviation (coefficient of variation) for a specified `threshold`. It
 is recommended to base the computation on quality control (QC) samples,
@@ -1228,64 +1278,6 @@ filtered_res <- filterFeatures(object = filtered_res,
 
 All features with an D-ratio strictly larger than 0.5 were thus removed from
 the data set.
-
-The `PercentMissingFilter` allows to filter features based on the percentage of
-missing values for each feature. This function takes as an input the parameter
-`f` which is supposed to be a vector of length equal to the length of the object
-(i.e. number of samples) with the sample type for each. The function then
-computes the percentage of missing values per sample groups and filters
-features based on this. Features with a percent of missing values larger than
-the threshold in all sample groups will be removed. Another option is to base
-this quality assessment and filtering only on QC samples.
-
-Both examples are shown below:
-
-```{r}
-# To set up parameter `f` to filter only based on QC samples
-f <- sampleData(filtered_faakho)$sample_type
-f[f != "QC"] <- NA
-
-# To set up parameter `f` to filter per sample type excluding QC samples
-f <- sampleData(filtered_faakho)$sample_type
-f[f == "QC"] <- NA
-
-missing_filter <- PercentMissingFilter(threshold = 30,
-                                       f = f)
-
-# Apply the filter to faakho object
-filtered_faakho <- filterFeatures(object = filtered_faakho,
-                                  filter = missing_filter)
-
-# Apply the filter to res object
-missing_filter <- PercentMissingFilter(threshold = 30,
-                                       f = f)
-filtered_res <- filterFeatures(object = filtered_res,
-                               filter = missing_filter)
-```
-
-Here, no feature was removed, meaning that all the features had less than 30%
-of `NA` values in at least one of the sample type.
-
-Although not directly relevant to this experiment, the `BlankFlag` filter can be
-used to flag features based on the intensity relationship between blank and QC
-samples. More information can be found in the documentation of the filter:
-
-```{r}
-# Retrieve documentation for the main function and the specific filter.
-?filterFeatures
-?BlankFlag
-```
-
-## Normalization
-
-Normalizing features' signal intensities is required, but at present not (yet)
-supported in `xcms` (some methods might be added in near future). It is advised
-to use the `SummarizedExperiment` returned by the `quantify()` method for any
-further data processing, as this type of object stores feature definitions,
-sample annotations as well as feature abundances in the same object. For the
-identification of e.g. features with significant different
-intensities/abundances it is suggested to use functionality provided in other R
-packages, such as Bioconductor's excellent *limma* package.
 
 
 ## Alignment to an external reference dataset

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -1203,17 +1203,13 @@ f[f != "QC"] <- NA
 f <- sampleData(faahko)$sample_type
 f[f == "QC"] <- NA
 
-missing_filter <- PercentMissingFilter(threshold = 30,
-                                       f = f)
+missing_filter <- PercentMissingFilter(threshold = 30, f = f)
 # Apply the filter to faakho object
-filtered_faahko <- filterFeatures(object = faahko,
-                                  filter = missing_filter)
+filtered_faahko <- filterFeatures(object = faahko, filter = missing_filter)
 
 # Apply the filter to res object
-missing_filter <- PercentMissingFilter(threshold = 30,
-                                       f = f)
-filtered_res <- filterFeatures(object = res,
-                               filter = missing_filter)
+missing_filter <- PercentMissingFilter(threshold = 30, f = f)
+filtered_res <- filterFeatures(object = res, filter = missing_filter)
 ```
 
 Here, no feature was removed, meaning that all the features had less than 30%

--- a/vignettes/xcms.Rmd
+++ b/vignettes/xcms.Rmd
@@ -1196,24 +1196,24 @@ Both examples are shown below:
 
 ```{r}
 # To set up parameter `f` to filter only based on QC samples
-f <- sampleData(filtered_faakho)$sample_type
+f <- sampleData(faahko)$sample_type
 f[f != "QC"] <- NA
 
 # To set up parameter `f` to filter per sample type excluding QC samples
-f <- sampleData(filtered_faakho)$sample_type
+f <- sampleData(faahko)$sample_type
 f[f == "QC"] <- NA
 
 missing_filter <- PercentMissingFilter(threshold = 30,
                                        f = f)
 
 # Apply the filter to faakho object
-filtered_faakho <- filterFeatures(object = filtered_faakho,
+filtered_faakho <- filterFeatures(object = faahko,
                                   filter = missing_filter)
 
 # Apply the filter to res object
 missing_filter <- PercentMissingFilter(threshold = 30,
                                        f = f)
-filtered_res <- filterFeatures(object = filtered_res,
+filtered_res <- filterFeatures(object = res,
                                filter = missing_filter)
 ```
 
@@ -1238,14 +1238,14 @@ as demonstrated below:
 ```{r}
 # Set up parameters for RsdFilter
 rsd_filter <- RsdFilter(threshold = 0.3,
-                        qcIndex = sampleData(faahko)$sample_type == "QC")
+                        qcIndex = sampleData(filtered_faahko)$sample_type == "QC")
 
 # Apply the filter to faakho object
-filtered_faahko <- filterFeatures(object = faahko, filter = rsd_filter)
+filtered_faahko <- filterFeatures(object = filtered_faahko, filter = rsd_filter)
 
 # Now apply the same strategy to the res object
-rsd_filter <- RsdFilter(threshold = 0.3, qcIndex = res$sample_type == "QC")
-filtered_res <- filterFeatures(object = res, filter = rsd_filter, assay = "raw")
+rsd_filter <- RsdFilter(threshold = 0.3, qcIndex = filtered_res$sample_type == "QC")
+filtered_res <- filterFeatures(object = filtered_res, filter = rsd_filter, assay = "raw")
 ```
 
 All features with an RSD (CV) strictly larger than 0.3 in QC samples were thus


### PR DESCRIPTION
@jorainer Just wanted to get your opinion on this.. Because appending multiple column at once to the `spectraData()` of an object is not possible. i only see 2 options: 
- accessing and manipulating the spectraData slot ( in this PR)
- a  `for` loop adding columns one by ones to the `res` object. 

Am I missing an easier way to deal with this ? 

This PR is not ready, just wanted to get your opinion before I also update `featureSpectra()` and the documentation.