### PR TITLE
fix: manualChromPeaks to support integrating a single peak

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.5.3
+Version: 4.5.4
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # xcms 4.5
 
+## Changes in version 4.5.4
+
+- Fix a bug in `manualChromPeaks()` that caused an error when only a single
+  chrom peak was added.
+
 ## Changes in version 4.5.3
 
 - Address issue #765: peak detection on chromatographic data: report a

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1192,7 +1192,8 @@ setMethod(
                  colnames(chromPeaks)))
             stop("'chromPeaks' lacks one or more of the required colums ",
                  "\"mzmin\", \"mzmax\", \"rtmin\" and \"rtmax\".")
-        chromPeaks <- chromPeaks[, c("mzmin", "mzmax", "rtmin", "rtmax")]
+        chromPeaks <- chromPeaks[, c("mzmin", "mzmax", "rtmin", "rtmax"),
+                                 drop = FALSE]
         if (!all(samples %in% seq_along(object)))
             stop("'samples' out of bounds")
         if (hasFeatures(object))

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1029,7 +1029,11 @@ test_that("manualChromPeaks,XcmsExperiment works", {
     res2 <- manualChromPeaks(tmp, pks, samples = 2)
     expect_equal(unname(chromPeaks(res2)), unname(pks_2))
 
-
+    ## Add single chrom peak
+    tmp <- as(mse, "XcmsExperiment")
+    res <- manualChromPeaks(tmp, pks[1L, , drop = FALSE])
+    expect_true(nrow(chromPeaks(res)) == 3L)
+    expect_equal(chromPeaks(res)[2, "maxo"], pks[1, "maxo"])
 })
 
 test_that("filterChromPeaks,XcmsExperiment works", {


### PR DESCRIPTION
This PR adds a fix to avoid an error when running `manualChromPeaks()` to integrate a single peak.

It includes a unit test, but @mar-garcia , please check that this fixes your error too.