### PR TITLE
Ensure retention times of chromatographic peaks are reverted for [,XcmsExperiment with keepAdjustRtime = FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.7.1
+Version: 4.7.2
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # xcms 4.7
 
+## Changes in version 4.7.2
+
+- Fix issue in `[,XcmsExperiment`: the subset operation did not revert the
+  retention times of chromatographic peaks with parameter `keepAdjustedRtime =
+  FALSE` (issue #801).
+
 ## Changes in version 4.7.1
 
 - Change the naming convention of chromatographic peaks to include also the MS

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Changes in version 4.7.2
 
+- Change default for `[,XcmsExperiment` and `[,XcmsExperimentHdf5`
+  `keepAdjustedRtime` from `FALSE` to `TRUE`.
 - Fix issue in `[,XcmsExperiment`: the subset operation did not revert the
   retention times of chromatographic peaks with parameter `keepAdjustedRtime =
   FALSE` (issue #801).

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
   FALSE` (issue #801).
 - Fix issue in `chromPeakSpectra` for `XcmsExperiment` with duplicated chrom
   peak IDs (issue #796).
+- Fix issue in `chromPeakSpectra()` for `XcmsExperiment` that added column
+  (sample) names to the resulting `XChromatograms` object with newer versions of
+  the *MsExperiment* package (>= 1.11.1); issue #803.
 
 ## Changes in version 4.7.1
 

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -71,7 +71,7 @@
 #' @noRd
 .subset_xcms_experiment <- function(x, i = integer(),
                                     keepChromPeaks = TRUE,
-                                    keepAdjustedRtime = FALSE,
+                                    keepAdjustedRtime = TRUE,
                                     keepFeatures = FALSE,
                                     ignoreHistory = FALSE,
                                     keepSampleIndex = FALSE, ...) {

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -86,12 +86,7 @@
         stop("Duplicated indices are not (yet) supported for ",
              "'[,XcmsExperiment'", call. = FALSE)
     drop <- character()
-    if (!keepAdjustedRtime && hasAdjustedRtime(x)) {
-        svs <- unique(c(spectraVariables(x@spectra), "mz", "intensity"))
-        x@spectra <- selectSpectraVariables(
-            x@spectra, svs[svs != "rtime_adjusted"])
-        drop <- c(drop, .PROCSTEP.RTIME.CORRECTION)
-    }
+    x <- getMethod("[", "MsExperiment")(x, i = i)
     if (!keepFeatures && hasFeatures(x)) {
         x@featureDefinitions <- .empty_feature_definitions()
         drop <- c(drop, .PROCSTEP.PEAK.GROUPING)
@@ -99,8 +94,22 @@
     if (hasChromPeaks(x)) {
         if (keepChromPeaks) {
             x <- .filter_chrom_peaks(x, which(x@chromPeaks[, "sample"] %in% i))
-            if (!keepSampleIndex)
+            sidx <- x@chromPeaks[, "sample"]
+            if (!keepAdjustedRtime && hasAdjustedRtime(x)) {
+                ## order of samples needs to match (between rtime and "sample")
+                ## column for .applyRtAdjToChromPeaks
                 x@chromPeaks[, "sample"] <- match(x@chromPeaks[, "sample"], i)
+                fidx <- as.factor(spectraSampleIndex(x))
+                x <- updateChromPeaksRtime(
+                    x, rtraw = split(rtime(x, adjusted = TRUE), fidx),
+                    rtadj = split(rtime(x, adjusted = FALSE), fidx))
+                if (keepSampleIndex)
+                    x@chromPeaks[, "sample"] <- sidx
+            } else {
+                if (!keepSampleIndex)
+                    x@chromPeaks[, "sample"] <- match(
+                        x@chromPeaks[, "sample"], i)
+            }
         } else {
             x@chromPeaks <- .empty_chrom_peaks()
             x@chromPeakData <- data.frame(ms_level = integer(),
@@ -109,10 +118,16 @@
                       .PROCSTEP.CALIBRATION, .PROCSTEP.PEAK.REFINEMENT)
         }
     }
+    if (!keepAdjustedRtime && hasAdjustedRtime(x)) {
+        svs <- unique(c(spectraVariables(x@spectra), "mz", "intensity"))
+        x@spectra <- selectSpectraVariables(
+            x@spectra, svs[svs != "rtime_adjusted"])
+        drop <- c(drop, .PROCSTEP.RTIME.CORRECTION)
+    }
     if (!ignoreHistory && length(drop))
         x@processHistory <- dropProcessHistoriesList(
             x@processHistory, type = drop)
-    getMethod("[", "MsExperiment")(x, i = i)
+    x
 }
 
 #' @param x `chromPeaks` `matrix`.

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -45,12 +45,12 @@
 #'
 #' - `[`: subset an `XcmsExperiment` by **sample** (parameter `i`). Subsetting
 #'   will by default drop correspondence results (as subsetting by samples will
-#'   obviously affect the feature definition) and alignment results (adjusted
-#'   retention times) while identified chromatographic peaks (for the selected
+#'   obviously affect the feature definition) while alignment results (adjusted
+#'   retention times) and identified chromatographic peaks (for the selected
 #'   samples) will be retained. Which preprocessing results should be
 #'   kept or dropped can also be configured with optional parameters
 #'   `keepChromPeaks` (by default `TRUE`), `keepAdjustedRtime` (by default
-#'   `FALSE`) and `keepFeatures` (by default `FALSE`).
+#'   `TRUE`) and `keepFeatures` (by default `FALSE`).
 #'
 #' - `c()`: multiple `XcmsExperiment` objects can be combined into one using the
 #'   `c()` function. This requires however that all the `XcmsExperiments`'

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1720,6 +1720,7 @@ setMethod(
             object <- applyAdjustedRtime(object)
         ph <- object@processHistory
         object <- as(object, "MsExperiment")
+        rownames(sampleData(object)) <- NULL # don't track sample names
         res <- lapply(seq_along(object), function(z) {
             idx <- which(pks[, "sample"] == z)
             if (length(idx)) {
@@ -1752,6 +1753,7 @@ setMethod(
         })
         res <- as(do.call(c, res[lengths(res) > 0]), return.type)
         pData(res)[,] <- NA             # it's not from a single file.
+        colnames(res) <- NULL
         ## re-order the result - if needed.
         if (any(rownames(res) != rownames(pks)))
             res <- res[match(rownames(pks), rownames(res)), 1L]

--- a/R/XcmsExperimentHdf5-functions.R
+++ b/R/XcmsExperimentHdf5-functions.R
@@ -185,6 +185,9 @@ toXcmsExperiment <- function(object, ...) {
     }
     drop <- character()
     if (!keepAdjustedRtime && hasAdjustedRtime(x)) {
+        if (hasChromPeaks(x) && keepChromPeaks)
+            stop("Reverting retention times of detected chromatographic peaks ",
+                 "is not supported. Please use 'keepAdjustedRtime = TRUE'.")
         svs <- unique(c(spectraVariables(x@spectra), "mz", "intensity"))
         x@spectra <- selectSpectraVariables(
             x@spectra, svs[svs != "rtime_adjusted"])

--- a/R/XcmsExperimentHdf5-functions.R
+++ b/R/XcmsExperimentHdf5-functions.R
@@ -173,7 +173,7 @@ toXcmsExperiment <- function(object, ...) {
 #' @noRd
 .h5_subset_xcms_experiment <- function(x, i = integer(),
                                        keepChromPeaks = TRUE,
-                                       keepAdjustedRtime = FALSE,
+                                       keepAdjustedRtime = TRUE,
                                        keepFeatures = FALSE,
                                        ignoreHistory = FALSE,
                                        ...) {

--- a/R/XcmsExperimentHdf5.R
+++ b/R/XcmsExperimentHdf5.R
@@ -69,7 +69,7 @@
 #'
 #' - `[`: subset the `XcmsExperimentHdf5` object to the specified samples.
 #'   Parameters `keepChromPeaks` (default `TRUE`), `keepAdjustedRtime`
-#'   (default `FALSE`) and `keepFeatures` (default `FALSE`) allow to configure
+#'   (default `TRUE`) and `keepFeatures` (default `FALSE`) allow to configure
 #'   whether present chromatographic peaks, alignment or correspondence results
 #'   should be retained. This will only change information in the object (i.e.,
 #'   the reference to the respective entries in the HDF5 file), but will

--- a/R/XcmsExperimentHdf5.R
+++ b/R/XcmsExperimentHdf5.R
@@ -73,8 +73,11 @@
 #'   whether present chromatographic peaks, alignment or correspondence results
 #'   should be retained. This will only change information in the object (i.e.,
 #'   the reference to the respective entries in the HDF5 file), but will
-#'   **not** change the content of the HDF5 file. Note that with
-#'   `keepChromPeaks = FALSE` also `keepFeatures` is set to `FALSE`.
+#'   **not** change the content of the HDF5 file. Thus, *reverting* the
+#'   retention times of detected chromatographic peaks is **not** supported and
+#'   `keepChromPeaks = TRUE` with `keepAdjustedRtime = FALSE` will throw an
+#'   error. Note that with `keepChromPeaks = FALSE` also `keepFeatures` is set
+#'   to `FALSE`.
 #'
 #' - `filterChromPeaks()` and `filterFeatureDefinitions()` to filter the
 #'   chromatographic peak and correspondence results, respectively. See

--- a/man/XcmsExperiment.Rd
+++ b/man/XcmsExperiment.Rd
@@ -447,12 +447,12 @@ be used instead. See the respective help page for more information.
 \itemize{
 \item \code{[}: subset an \code{XcmsExperiment} by \strong{sample} (parameter \code{i}). Subsetting
 will by default drop correspondence results (as subsetting by samples will
-obviously affect the feature definition) and alignment results (adjusted
-retention times) while identified chromatographic peaks (for the selected
+obviously affect the feature definition) while alignment results (adjusted
+retention times) and identified chromatographic peaks (for the selected
 samples) will be retained. Which preprocessing results should be
 kept or dropped can also be configured with optional parameters
 \code{keepChromPeaks} (by default \code{TRUE}), \code{keepAdjustedRtime} (by default
-\code{FALSE}) and \code{keepFeatures} (by default \code{FALSE}).
+\code{TRUE}) and \code{keepFeatures} (by default \code{FALSE}).
 \item \code{c()}: multiple \code{XcmsExperiment} objects can be combined into one using the
 \code{c()} function. This requires however that all the \code{XcmsExperiments}'
 \code{Spectra} objects use the same type of \code{MsBackend} and that their

--- a/man/XcmsExperimentHdf5.Rd
+++ b/man/XcmsExperimentHdf5.Rd
@@ -154,8 +154,11 @@ Parameters \code{keepChromPeaks} (default \code{TRUE}), \code{keepAdjustedRtime}
 whether present chromatographic peaks, alignment or correspondence results
 should be retained. This will only change information in the object (i.e.,
 the reference to the respective entries in the HDF5 file), but will
-\strong{not} change the content of the HDF5 file. Note that with
-\code{keepChromPeaks = FALSE} also \code{keepFeatures} is set to \code{FALSE}.
+\strong{not} change the content of the HDF5 file. Thus, \emph{reverting} the
+retention times of detected chromatographic peaks is \strong{not} supported and
+\code{keepChromPeaks = TRUE} with \code{keepAdjustedRtime = FALSE} will throw an
+error. Note that with \code{keepChromPeaks = FALSE} also \code{keepFeatures} is set
+to \code{FALSE}.
 \item \code{filterChromPeaks()} and \code{filterFeatureDefinitions()} to filter the
 chromatographic peak and correspondence results, respectively. See
 documentation below for details. Subset using unsorted or duplicated

--- a/man/XcmsExperimentHdf5.Rd
+++ b/man/XcmsExperimentHdf5.Rd
@@ -150,7 +150,7 @@ are stored in the file specified with parameter \code{hdf5File}.
 \itemize{
 \item \code{[}: subset the \code{XcmsExperimentHdf5} object to the specified samples.
 Parameters \code{keepChromPeaks} (default \code{TRUE}), \code{keepAdjustedRtime}
-(default \code{FALSE}) and \code{keepFeatures} (default \code{FALSE}) allow to configure
+(default \code{TRUE}) and \code{keepFeatures} (default \code{FALSE}) allow to configure
 whether present chromatographic peaks, alignment or correspondence results
 should be retained. This will only change information in the object (i.e.,
 the reference to the respective entries in the HDF5 file), but will

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -171,6 +171,35 @@ test_that("subsetting,XcmsExperiment works", {
     expect_true(length(res) == (length(xmse) - 1))
     ref <- xmse[c(2, 3)]
     expect_equal(chromPeaks(res), chromPeaks(ref))
+
+    ## subsetting with alignment results.
+    tmp <- adjustRtime(xmseg, PeakGroupsParam(span = 0.4))
+    a <- tmp[3, keepAdjustedRtime = TRUE]
+    b <- tmp[3, keepAdjustedRtime = FALSE]
+    expect_true(length(a@processHistory) > length(b@processHistory))
+    expect_false(all(rtime(a) == rtime(b)))
+    expect_false(all(chromPeaks(a)[, "rt"] == chromPeaks(b)[, "rt"]))
+
+    ## subset in arbitrary order
+    a <- tmp[c(3, 1), keepAdjustedRtime = TRUE]
+    a_rt <- split(rtime(a, adjusted = TRUE), spectraSampleIndex(a))
+    tmp_rt <- split(rtime(tmp, adjusted = TRUE), spectraSampleIndex(tmp))
+    expect_equal(a_rt[[1L]], tmp_rt[[3L]])
+    expect_equal(a_rt[[2L]], tmp_rt[[1L]])
+    a_pks <- split.data.frame(chromPeaks(a), chromPeaks(a)[, "sample"])
+    tmp_pks <- split.data.frame(chromPeaks(tmp), chromPeaks(tmp)[, "sample"])
+    expect_equal(a_pks[[1L]][, 1:8], tmp_pks[[3L]][, 1:8])
+    expect_equal(a_pks[[2L]][, 1:8], tmp_pks[[1L]][, 1:8])
+
+    a <- tmp[c(3, 1), keepAdjustedRtime = FALSE]
+    a_rt <- split(rtime(a), spectraSampleIndex(a))
+    tmp_rt <- split(rtime(tmp, adjusted = FALSE), spectraSampleIndex(tmp))
+    expect_equal(a_rt[[1L]], tmp_rt[[3L]])
+    expect_equal(a_rt[[2L]], tmp_rt[[1L]])
+    a_pks <- split.data.frame(chromPeaks(a), chromPeaks(a)[, "sample"])
+    tmp_pks <- split.data.frame(chromPeaks(xmse), chromPeaks(xmse)[, "sample"])
+    expect_equal(a_pks[[1L]][, 1:8], tmp_pks[[3L]][, 1:8])
+    expect_equal(a_pks[[2L]][, 1:8], tmp_pks[[1L]][, 1:8])
 })
 
 test_that("filterRt,XcmsExperiment works", {

--- a/tests/testthat/test_XcmsExperimentHdf5-functions.R
+++ b/tests/testthat/test_XcmsExperimentHdf5-functions.R
@@ -247,6 +247,9 @@ test_that(".h5_chrom_peak_ms_levels works", {
 test_that(".h5_subset_xcms_experiment works", {
     expect_error(.h5_subset_xcms_experiment(
         xmseg_full_h5 , c(2, 4, -1, 3, -4)), "Mixing positive")
+    expect_error(.h5_subset_xcms_experiment(
+        xmseg_full_h5, c(1, 2), keepAdjustedRtime = FALSE,
+        keepChromPeaks = TRUE), "Reverting retention times")
 
     a <- new("XcmsExperimentHdf5")
     res <- .h5_subset_xcms_experiment(a)
@@ -271,8 +274,8 @@ test_that(".h5_subset_xcms_experiment works", {
     expect_false(hasChromPeaks(res))
     expect_equal(res@processHistory, a@processHistory)
 
-    res <- .h5_subset_xcms_experiment(xmseg_full_h5, c(3, 1),
-                                      keepFeatures = TRUE)
+    res <- .h5_subset_xcms_experiment(
+        xmseg_full_h5, c(3, 1), keepFeatures = TRUE, keepAdjustedRtime = TRUE)
     expect_true(hasFeatures(res))
     expect_true(length(res) == 2)
     expect_equal(featureDefinitions(res), featureDefinitions(xmseg_full_h5))
@@ -281,14 +284,15 @@ test_that(".h5_subset_xcms_experiment works", {
     expect_equal(a[a[, "sample"] == 1, 1:10], b[b[, "sample"] == 3, 1:10])
     expect_equal(a[a[, "sample"] == 2, 1:10], b[b[, "sample"] == 1, 1:10])
 
-    res <- .h5_subset_xcms_experiment(xmseg_full_h5, c(3, 1),
-                                      keepFeatures = FALSE)
+    res <- .h5_subset_xcms_experiment(
+        xmseg_full_h5, c(3, 1), keepFeatures = FALSE, keepAdjustedRtime = TRUE)
     expect_false(hasFeatures(res))
     expect_true(length(res) == 2)
 
     res <- .h5_subset_xcms_experiment(xmseg_full_h5, c(3, 1),
                                       keepFeatures = TRUE,
-                                      keepChromPeaks = FALSE)
+                                      keepChromPeaks = FALSE,
+                                      keepAdjustedRtime = TRUE)
     expect_false(hasFeatures(res))
     expect_false(hasChromPeaks(res))
     expect_true(length(res) == 2)

--- a/tests/testthat/test_methods-XCMSnExp.R
+++ b/tests/testthat/test_methods-XCMSnExp.R
@@ -2624,3 +2624,12 @@ test_that("adjustRtimePeakGroups works", {
                                  param = PeakGroupsParam(subset = c(1, 3)))
     expect_equal(colnames(res), basename(fileNames(xod_xg)[c(1, 3)]))
 })
+
+test_that("subset XCMSnExp works with adjusted rtime", {
+    ## subsetting with/without keepAdjustedRtime
+    a <- filterFile(xod_xgr, 3, keepAdjustedRtime = TRUE)
+    b <- filterFile(xod_xgr, 3, keepAdjustedRtime = FALSE)
+    expect_false(all(rtime(a) == rtime(b)))
+    expect_false(all(chromPeaks(a)[, "rt"] == chromPeaks(b)[, "rt"]))
+    expect_equal(chromPeaks(b), chromPeaks(filterFile(xod_xg, 3)))
+})


### PR DESCRIPTION
This PR fixes the issue #801 , i.e., ensures that the retention times of chromatographic peaks are also, along with the spectra's retention times, reverted for subset of `XcmsExperiment` using the `[` method and using parameter `keepAdjustedRtime = FALSE`.

In addition, this PR also changes the default for `keepAdjustedRtime` from `FALSE` to `TRUE` to match the default value of the related `filterFile()` function.

I would then also make a PR to the release branch, as this is an important bug fix we should also have in the BioC 3.21 release version.