### PR TITLE
fix: chromPeakSpectra,XcmsExperiment for updated MsExperiment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # xcms 4.6
 
+## Changes in version 4.6.2
+
+- Fix issue in `chromPeakSpectra()` for `XcmsExperiment` reporting also
+  (wrongly) the column (sample) names in the resulting `XChromatograms` object
+  for *MsExperiment* versions >= 1.10.1.
+
 ## Changes in version 4.6.1
 
 - Fix issue in `chromPeakSpectra` for `XcmsExperiment` with duplicated chrom

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1657,6 +1657,7 @@ setMethod(
             object <- applyAdjustedRtime(object)
         ph <- object@processHistory
         object <- as(object, "MsExperiment")
+        rownames(sampleData(object)) <- NULL # sample names are not supported
         res <- lapply(seq_along(object), function(z) {
             idx <- which(pks[, "sample"] == z)
             if (length(idx)) {


### PR DESCRIPTION
- Fix `chromPeakSpectra()` for `XcmsExperiment` objects for *MsExperiment* package versions >= 1.10.1: don't report column (sample) names for the resulting `XChromatograms` (issue #803, #804).