### PR TITLE
fix: disable gettext in massifquant

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -159,6 +159,7 @@ jobs:
           BiocManager::install("mzR")
           BiocManager::install("MsExperiment")
           BiocManager::install("MSnbase")
+          BiocManager::install("faahKO")
 
           BiocManager::install(c("rmarkdown", "BiocStyle"), type = "source")
         continue-on-error: true

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -152,21 +152,13 @@ jobs:
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
 
-          ## Workaround for problems with cached S4objects in binary packages
-          BiocManager::install("GenomeInfoDb", force = TRUE, type = "source")
-          BiocManager::install("BiocParallel", force = TRUE, type = "source")
-          BiocManager::install("S4Vectors", force = TRUE, type = "source")
-          BiocManager::install("SummarizedExperiment", force = TRUE, type = "source")
-          ## install xcms with dependencies - to ensure dependencies are installed from source;
-          ## somehow install_local installs binary packages instead.
-          BiocManager::install("mzR", force = TRUE)
-          BiocManager::install("MSnbase", force = TRUE, type = "source")
-          BiocManager::install("xcms", force = TRUE, type = "source", dependencies = TRUE)
-          BiocManager::install("faahKO", type = "source")
-
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
           remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = FALSE, build_manual = FALSE, type = "source")
+
+          BiocManager::install("mzR")
+          BiocManager::install("MsExperiment")
+          BiocManager::install("MSnbase")
 
           BiocManager::install(c("rmarkdown", "BiocStyle"), type = "source")
         continue-on-error: true
@@ -180,7 +172,6 @@ jobs:
 
           ## Manually install packages that seem to be skipped.
           message(paste('****', Sys.time(), 'force installation of selected packages  ****'))
-          BiocManager::install("RforMassSpectrometry/MsCoreUtils", force = TRUE)
           BiocManager::install("magick", type = "source")
 
           ## For running the checks

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.6.2
+Version: 4.6.3
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # xcms 4.6
 
+## Changes in version 4.6.3
+
+- Fix compiler error for massifquant on macOS (issue #804).
+
 ## Changes in version 4.6.2
 
 - Fix issue in `chromPeakSpectra()` for `XcmsExperiment` reporting also

--- a/src/massifquant/nmath.h
+++ b/src/massifquant/nmath.h
@@ -70,12 +70,7 @@ void R_CheckUserInterrupt(void);
 #endif
 #define free R_chk_free
 
-#ifdef ENABLE_NLS
-#include <libintl.h>
-#define _(String) gettext (String)
-#else
 #define _(String) (char *)(String)
-#endif
 
 #else
 /* Mathlib standalone */


### PR DESCRIPTION
- Compilers on macOS don't provide gettext anymore (or ship a different version that does no longer include the libintl.h). This fix disables use of libintl.h and fixes issue #804.