### PR TITLE
replaced misleading explanation of applyAdjustedRtime

### DIFF
--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -910,8 +910,9 @@ isCalibrated <- function(object) {
 #'
 #' @details
 #'
-#' Adjusted retention times are stored *in parallel* to the adjusted
-#' retention times in `XCMSnExp` or `XcmsExperiment` objects. The
+#' Adjusted retention times are stored in an `XCMSnExp` or `XcmsExperiment` 
+#' object besides the original, raw, retention times, allowing to switch 
+#' between raw and adjusted times.
 #' `applyAdjustedRtime` replaces the raw (original) retention times with the
 #' adjusted retention times.
 #'


### PR DESCRIPTION
I assume "*in parallel* to the adjusted" should have been "*in parallel* to the raw" . I replaced with a text similar to that in DataClasses.R.