### PR TITLE
Fix issue when completely overlapping peaks are not combined

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.9.1
+Version: 4.9.2
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.9.0
+Version: 4.9.1
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# xcms 4.9
+
+## Changes in version 4.9.1
+
+- Fix issue with `refineChromPeaks()` and `MergeNeighboringPeaksParam` where in
+  certain cases completely overlapping peaks were not merged (issue #825).
+
 # xcms 4.7
 
 ## Changes in version 4.7.3

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -232,7 +232,7 @@
                                                 diffRt = 0) {
     if (!length(pks) || nrow(pks) < 2)
         return(list(chromPeaks = pks, chromPeakData = pkd))
-    idx <- order(pks[, "rtmin"])
+    idx <- order(pks[, "rtmin"], -pks[, "rtmax"])
     pks <- pks[idx, , drop = FALSE]
     pkd <- pkd[idx, , drop = FALSE]
     rownames(pkd) <- NULL

--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -77,7 +77,7 @@
     if (nrow(pks) < 2 || all(is.na(intensity(x))))
         return(list(chromPeaks = pks, chromPeakData = pkd))
     ## x <- clean(x, all = TRUE)
-    idx <- order(pks[, "rtmin"])
+    idx <- order(pks[, "rtmin"], -pks[, "rtmax"])
     pks <- pks[idx, , drop = FALSE]
     pkd <- extractROWS(pkd, idx)
     cns <- colnames(pks)

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -672,6 +672,35 @@ test_that(".merge_neighboring_peak_candidates works", {
     res <- .merge_neighboring_peak_candidates(pd, rt, pks, pkd, diffRt = 8,
                                               ppm = 10, expandMz = 0)
     expect_equal(res$chromPeaks, pks)
+
+    ## issue #825
+    pks <- rbind(
+        c(666.0693, 666.0693, 666.0693, 31.779, 27.59, 35.968, 1, 1, 1, 1, 1),
+        c(666.0713, 666.0683, 666.0747, 31.181, 27.59, 39.559, 2, 2, 2, 2, 1),
+        c(666.0693, 666.0693, 666.0693, 31.779, 27.59, 36.968, 3, 3, 3, 3, 1))
+    colnames(pks) <- c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "into",
+                       "intb", "maxo", "sn", "sample")
+    rownames(pks) <- c("A", "B", "C")
+
+    pkd <- data.frame(ms_level = rep(1L, 3), is_filled = rep(FALSE, 3))
+    x <- list(cbind(mz = c(), intensity = c()),
+              cbind(mz = c(), intensity = c()),
+              cbind(mz = c(), intensity = c()))
+    rt <- c(30.5, 31.5, 32.5)
+
+    res <- .merge_neighboring_peak_candidates(pd, rt, pks, pkd)$chromPeaks
+    expect_true(nrow(res) == 1L)
+    expect_equal(rownames(res), "B")
+
+    res <- .merge_neighboring_peak_candidates(
+        pd, rt, pks[c(2, 3, 1), ], pkd)$chromPeaks
+    expect_true(nrow(res) == 1L)
+    expect_equal(rownames(res), "B")
+
+    res <- .merge_neighboring_peak_candidates(
+        pd, rt, pks[c(3, 1, 2), ], pkd)$chromPeaks
+    expect_true(nrow(res) == 1L)
+    expect_equal(rownames(res), "B")
 })
 
 ## That's from XcmsExperiment-functions.R
@@ -680,7 +709,7 @@ test_that(".merge_neighboring_peaks2 works", {
     tmp2 <- xmse[1L]
     x <- Spectra::peaksData(filterMsLevel(spectra(tmp2), 1L))
     pks <- chromPeaks(tmp2, msLevel = 1L)
-    pkd <- chromPeaks(tmp2, msLevel = 1L)
+    pkd <- chromPeakData(tmp2, msLevel = 1L)
     rt <- rtime(tmp2)[msLevel(spectra(tmp2)) == 1L]
     prm <- MergeNeighboringPeaksParam(expandRt = 6, expandMz = 1)
 
@@ -701,7 +730,7 @@ test_that(".merge_neighboring_peaks2 works", {
     tmp2 <- xmse[2L]
     x <- Spectra::peaksData(filterMsLevel(spectra(tmp2), 1L))
     pks <- chromPeaks(tmp2, msLevel = 1L)
-    pkd <- chromPeaks(tmp2, msLevel = 1L)
+    pkd <- chromPeakData(tmp2, msLevel = 1L)
     rt <- rtime(tmp2)[msLevel(spectra(tmp2)) == 1L]
     ref <- refineChromPeaks(tmp1, prm)
     res <- .merge_neighboring_peaks2(x, pks, pkd, rt,


### PR DESCRIPTION
This PR fixes issue #825 , i.e., solves an issue that can cause completely overlapping chromatographics to be **not** merged by `refineChromPeaks()` with `MergeNeighboringPeaksParam`.