### PR TITLE
Fix .merge_neighboring_peaks2 early-return missing npeaks element

### DIFF
--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -334,7 +334,7 @@
                                       expandMz = 0, ppm = 10, minProp = 0.75) {
     cands <- .define_merge_candidates(pks, expandMz, ppm, expandRt)
     if (!length(cands))
-        return(list(chromPeaks = pks, chromPeakData = pkd))
+        return(list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks)))
     cands <- cands[[2L]]
     pks_new <- pkd_new <- vector("list", length(cands))
     for (i in seq_along(cands)) {


### PR DESCRIPTION

## Problem

`.merge_neighboring_peaks2()` has two return paths:

1. **Normal path** (after merging): returns `list(chromPeaks = ..., chromPeakData = ..., npeaks = ...)`
2. **Early-return path** (no merge candidates): returns `list(chromPeaks = pks, chromPeakData = pkd)` — **missing `npeaks`**

The calling code in `.xmse_merge_neighboring_peaks()` extracts the third element from every per-file result:

```r
npeaks = vapply(res, `[[`, i = 3L, integer(1))
```

When a file has detected peaks but none are close enough to be merge candidates (well-separated in m/z), the early-return path is taken and the list has only 2 elements. Extracting `[[3L]]` then fails with:

```
Error in .subset2(x, i, exact = exact) : subscript out of bounds
```

This is data-dependent — it crashes when at least one file in the experiment has peaks where no pair overlaps in m/z (within `ppm` tolerance).

## Fix

Add `npeaks = nrow(pks)` to the early-return list, consistent with the normal return path:

```r
## Before:
return(list(chromPeaks = pks, chromPeakData = pkd))

## After:
return(list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks)))
```

## Reproducible example

Uses the faahKO dataset (available via `BiocManager::install("faahKO")`).
With restrictive CentWave parameters some files end up with few, well-separated
peaks — exactly the condition that triggers the early-return bug.

```r
library(xcms)
library(MsExperiment)
register(SerialParam())

## Read the faahKO raw data
fls <- dir(system.file("cdf", package = "faahKO"),
           full.names = TRUE, recursive = TRUE)
raw <- readMsExperiment(fls)

## Restrictive peak picking → few peaks per file
cwp <- CentWaveParam(peakwidth = c(20, 40), noise = 20000,
                     snthresh = 100, ppm = 5)
xmse <- findChromPeaks(raw, param = cwp)

## File 1 ends up with 16 well-separated peaks — zero merge candidates.
## Confirm:
pks1 <- chromPeaks(xmse[1L], msLevel = 1L)
cands <- xcms:::.define_merge_candidates(pks1, expandMz = 0, ppm = 10,
                                          expandRt = 2)
cat("File 1:", nrow(pks1), "peaks,", length(cands), "candidate groups\n")
## File 1: 16 peaks, 0 candidate groups

## Without the fix, refineChromPeaks crashes:
prm <- MergeNeighboringPeaksParam(expandRt = 2, expandMz = 0, ppm = 10)
refineChromPeaks(xmse, param = prm)
## Fejl i FUN(X[[i]], ...) : subscript out of bounds

## With the fix applied, it completes normally:
## Reduced from 205 to 147 chromatographic peaks.
```
