### PR TITLE
Avoid unnecessary/misleading warning in refineChromPeaks

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -53,9 +53,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:devel", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
-          - { os: macOS-latest, r: 'devel', bioc: 'devel'}
-          - { os: windows-latest, r: 'devel', bioc: 'devel'}
+          - { os: ubuntu-latest, r: 'devel', bioc: 'devel', cont: "bioconductor/bioconductor_docker:RELEASE_3_23", rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest" }
+          - { os: macOS-latest, r: 'latest', bioc: '3.23'}
+          - { os: windows-latest, r: 'latest', bioc: '3.23'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -159,24 +159,15 @@ jobs:
           ## https://stat.ethz.ch/pipermail/bioc-devel/2020-April/016675.html
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
-
-          ## Workaround for problems with cached S4objects in binary packages
-          BiocManager::install("GenomeInfoDb", force = TRUE, type = "source")
-          BiocManager::install("BiocParallel", force = TRUE, type = "source")
-          BiocManager::install("S4Vectors", force = TRUE, type = "source")
-          BiocManager::install("SummarizedExperiment", force = TRUE, type = "source")
-          ## install xcms with dependencies - to ensure dependencies are installed from source;
-          ## somehow install_local installs binary packages instead.
-          BiocManager::install("mzR", force = TRUE)
-          BiocManager::install("MSnbase", force = TRUE, type = "source")
-          BiocManager::install("xcms", force = TRUE, type = "source", dependencies = TRUE)
-          BiocManager::install("faahKO", type = "source")
+          install.packages("pak")
+          pak::local_install_dev_deps(ask = FALSE)
+          pak::local_install(depdendencies = TRUE)
+          BiocManager::install(c("rmarkdown", "BiocStyle"))
 
           ## Pass #1 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 1 at installing dependencies: local dependencies ****'))
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = FALSE, build_manual = FALSE, type = "source")
+          ##remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = FALSE, build_manual = FALSE, type = "source")
 
-          BiocManager::install(c("rmarkdown", "BiocStyle"), type = "source")
         continue-on-error: true
         shell: Rscript {0}
 
@@ -184,17 +175,18 @@ jobs:
         run: |
           ## Pass #2 at installing dependencies
           message(paste('****', Sys.time(), 'pass number 2 at installing dependencies: any remaining dependencies ****'))
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = FALSE, type = "source")
+          ## remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories(), build_vignettes = FALSE, type = "source")
+          pak::local_install(dependencies = TRUE)
 
           ## Manually install packages that seem to be skipped.
-          message(paste('****', Sys.time(), 'force installation of selected packages  ****'))
-          BiocManager::install("RforMassSpectrometry/MsCoreUtils", force = TRUE)
-          BiocManager::install("magick", type = "source")
+          # message(paste('****', Sys.time(), 'force installation of selected packages  ****'))
+          # BiocManager::install("RforMassSpectrometry/MsCoreUtils", force = TRUE)
+          # BiocManager::install("magick", type = "source")
 
           ## For running the checks
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
-          remotes::install_cran("rcmdcheck", type = "source")
-          BiocManager::install("BiocCheck", type = "source")
+          remotes::install_cran("rcmdcheck")
+          BiocManager::install("BiocCheck")
         shell: Rscript {0}
 
       - name: Install BiocGenerics

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.10.0
+Version: 4.10.1
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# xcms
+
+## Changes in version
+
+- `refineChromPeaks,MergeNeighboringPeakParam`: drop row names of intermediate
+  objects to avoid potentially misleading warning message.
+
 # xcms 4.9
 
 ## Changes in version 4.9.4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# xcms
+# xcms 4.10
 
-## Changes in version
+## Changes in version 4.10.1
 
 - `refineChromPeaks,MergeNeighboringPeakParam`: drop row names of intermediate
   objects to avoid potentially misleading warning message.

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -339,6 +339,7 @@
         return(list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks)))
     cands <- cands[[2L]]
     pks_new <- pkd_new <- vector("list", length(cands))
+    rownames(pkd) <- NULL
     for (i in seq_along(cands)) {
         res <- .merge_neighboring_peak_candidates(
             x, rt = rt, pks[cands[[i]], , drop = FALSE],
@@ -360,6 +361,7 @@
     if (any(news)) {
         pks <- rbind(pks, pks_new[news, , drop = FALSE])
         pkd <- rbind(pkd, pkd_new[news, , drop = FALSE])
+        rownames(pkd) <- NULL
     }
     list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks))
 }

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -339,17 +339,17 @@
         return(list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks)))
     cands <- cands[[2L]]
     pks_new <- pkd_new <- vector("list", length(cands))
-    rownames(pkd) <- NULL
     for (i in seq_along(cands)) {
         res <- .merge_neighboring_peak_candidates(
             x, rt = rt, pks[cands[[i]], , drop = FALSE],
             pkd[cands[[i]], , drop = FALSE], diffRt = 2 * expandRt,
             minProp = minProp, expandMz = expandMz, ppm = ppm)
-         pks_new[[i]] <- res$chromPeaks
+        pks_new[[i]] <- res$chromPeaks
         pkd_new[[i]] <- res$chromPeakData
     }
     pks_new <- do.call(rbind, pks_new)
-    pkd_new <- rbindlistWithRownames(pkd_new, use.names = TRUE, fill = TRUE)
+    suppressWarnings(pkd_new <- rbindlistWithRownames(
+                         pkd_new, use.names = TRUE, fill = TRUE))
     ## drop peaks that were candidates, but that were not returned (i.e.
     ## were either merged or dropped)
     keep <- !(rownames(pks) %in% setdiff(unlist(cands, use.names = FALSE),
@@ -361,8 +361,8 @@
     if (any(news)) {
         pks <- rbind(pks, pks_new[news, , drop = FALSE])
         pkd <- rbind(pkd, pkd_new[news, , drop = FALSE])
-        rownames(pkd) <- NULL
     }
+    rownames(pkd) <- NULL
     list(chromPeaks = pks, chromPeakData = pkd, npeaks = nrow(pks))
 }
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -12,7 +12,7 @@ faahko_3_files <- c(system.file('cdf/KO/ko15.CDF', package = "faahKO"),
                     system.file('cdf/KO/ko16.CDF', package = "faahKO"),
                     system.file('cdf/KO/ko18.CDF', package = "faahKO"))
 fticrf <- c(HAM004_641fE_14.11.07..Exp1.extracted.mzML(),
-            HAM004_641fE_14.11.07..Exp2.extracted.mzML())
+            HAM004_641fE_14.11.07..Exp2.extracted.mzML()) |> normalizePath()
 pest_mix_swath_file <- PestMix1_SWATH.mzML()
 pest_mix_dda_file <- PestMix1_DDA.mzML()
 


### PR DESCRIPTION
This PR is a duplicate of PR #834 , only for the release branch, instead of the devel branch. Info on the PR:

`refineChromPeaks,XcmsExperiment,MergeNeighboringPeaksParam` was showing a warning about duplicated row names, but this was thrown by an internal merging of results - on temporary `data.frame`s/sub sets of the `chromPeakData()`. This PR is removing the row names from these intermediate objects. The final (real) row names of `chromPeakData()` were (and are) assigned correctly at the end of the call.