### PR TITLE
fix(profMat): correct .insertColumn boundary handling for empty spectra (fixes #366)

### DIFF
--- a/R/functions-utils.R
+++ b/R/functions-utils.R
@@ -595,14 +595,13 @@ rowRla <- function(x, group, log.transform = TRUE) {
             stop("length of 'pos' and 'val' have to match")
     }
     for (i in seq_along(pos)) {
-        if (pos[i] == 1) {
+        if (pos[i] == 1L)
             x <- cbind(val[[i]], x)
-        } else {
-            if (pos[i] == ncol(x))
-                x <- cbind(x, val[[i]])
-            else
-                x <- cbind(x[, 1:(pos[i]-1)], val[[i]], x[, pos[i]:ncol(x)])
-        }
+        else if (pos[i] > ncol(x))
+            x <- cbind(x, val[[i]])
+        else
+            x <- cbind(x[, 1:(pos[i] - 1), drop = FALSE], val[[i]],
+                       x[, pos[i]:ncol(x), drop = FALSE])
     }
     x
 }

--- a/tests/testthat/test_functions-utils.R
+++ b/tests/testthat/test_functions-utils.R
@@ -205,6 +205,23 @@ test_that(".insertColumn works", {
     expect_true(ncol(res) == ncol(mat) + 2)
     expect_equal(res[, 2], 101:120)
     expect_equal(res[, 4], 101:120)
+
+    ## Boundary cases (previously broken):
+    ## insert AT the last column -> value goes to that position, old cols shift
+    res <- .insertColumn(mat, ncol(mat), 5)
+    expect_true(all(res[, ncol(mat)] == 5))
+    expect_equal(ncol(res), ncol(mat) + 1)
+    expect_equal(res[, -ncol(mat)], mat)
+    ## insert past the end (e.g. trailing empty spectrum) -> append, no error
+    res <- .insertColumn(mat, ncol(mat) + 1L, 5)
+    expect_equal(ncol(res), ncol(mat) + 1)
+    expect_true(all(res[, ncol(res)] == 5))
+    expect_equal(res[, -ncol(res)], mat)
+    ## multiple inserts including a trailing one must not error
+    expect_silent(.insertColumn(mat, c(2, ncol(mat) + 1L), 0))
+    ## single-row input with a trailing insert
+    m1 <- matrix(c(11, 12), nrow = 1)
+    expect_equal(unname(.insertColumn(m1, 3, 0)[1, ]), c(11, 12, 0))
 })
 
 test_that(".ppm_range works", {


### PR DESCRIPTION
# Fix: `profMat()` errors (`subscript out of bounds`) when a file has trailing / adjacent empty spectra

> **AI-assisted contribution.** This report and the accompanying code fix were
> prepared with the assistance of Claude Code. The reproducible example and every
> quoted output were produced by actually running the code against the `xcms`
> source; the change is covered by a regression test.

## Summary

`.insertColumn()` (`R/functions-utils.R`) is used by the `profMat()` methods to
re-insert zero columns for **empty spectra** so that the returned profile matrix
has one column per spectrum (`ncol(profMat) == length(rtime)`; the fix for
issue #312). The helper mis-handles two boundary cases:

1. **Insert position past the current last column** (`pos > ncol(x)`) — happens
   whenever the empty spectrum is the **last** spectrum, or a run of empty
   spectra sits at the end. The `else` branch evaluates `x[, pos[i]:ncol(x)]`
   with `pos[i] == ncol(x) + 1`, i.e. `x[, (ncol+1):ncol]`, which is out of
   bounds → **error**.

2. **Insert position exactly at the last column** (`pos == ncol(x)`) — the code
   takes a special branch that **appends** the column at the end
   (`cbind(x, val)`) instead of inserting it *at* `pos`. The new (empty) column
   therefore lands one position too far to the right → **silent column
   misalignment** between the profile matrix and the retention times.

Empty spectra are common (scans with no peaks in the requested m/z range, after
centroiding, or after `filterMz()`), so `profMat()` can crash on ordinary data.

## Related GitHub issues

- **Fixes #366** ("adjustRtime subscript out of bounds error", still open). The
  reporter's traceback is this exact bug: `Error in x[, pos[i]:ncol(x)] :
  subscript out of bounds` raised inside `.insertColumn()` →
  `.local()` (profMat) → `.obiwarp()` → `adjustRtime(ObiwarpParam())`. **Three**
  independent users hit it (2019–2020), and the suggested workaround was
  `filterEmptySpectra()` before alignment — which confirms the empty-spectra
  root cause. This fix removes the need for that workaround.
- **Related (same empty-spectra-in-obiwarp root):** #242, #194, #474, #492, #506
  and #676 all report obiwarp/profile-matrix failures ("Dimensions of profile
  matrices do not match", "attempt to apply non-function", `bad_array_length`)
  on data with empty/gappy spectra, with `filterEmptySpectra()` repeatedly given
  as the workaround. Some of these ride the legacy `retcor.obiwarp` path rather
  than `.insertColumn` directly; they are listed as *related*, not all fixed by
  this single change.

## Reproducible example

End-to-end crash of the public `profMat()` method on `faahKO`, restricting to an
m/z window that leaves several spectra — including the **last** one — empty:

```r
library(xcms)
library(MSnbase)
library(faahKO)
library(BiocParallel)
register(SerialParam())

fl  <- dir(system.file("cdf", package = "faahKO"), recursive = TRUE,
           full.names = TRUE)[1]                       # ko15.CDF
raw <- readMSData(fl, mode = "onDisk")

sub <- filterMz(raw, mz = c(599, 600))
sum(lengths(mz(sub)) == 0)                 #> 189 empty spectra
lengths(mz(sub))[length(mz(sub))] == 0     #> TRUE   (last spectrum is empty)

profMat(sub, step = 1)
#> Error in x[, pos[i]:ncol(x)] : subscript out of bounds
```

Both failure modes can also be reproduced directly on the helper (current
source):

```r
## trailing empty spectrum -> pos == ncol + 1 -> hard error
xcms:::.insertColumn(matrix(c(11, 13), nrow = 1), c(2, 4), 0)
#> Error in x[, pos[i]:ncol(x)] : subscript out of bounds

## pos == ncol -> column silently appended at the end instead of inserted
xcms:::.insertColumn(matrix(c(1, 2, 3), nrow = 1), 3, 0)
#>      [,1] [,2] [,3] [,4]
#> [1,]    1    2    3    0     # WRONG: want 1 2 0 3
```

With this fix, `profMat(sub, step = 1)` returns a matrix with one column per
spectrum (1278), and the two helper calls above return `11 0 13 0` and
`1 2 0 3` respectively.
