### PR TITLE
fix(filterFeatureDefinitions): remove all features on explicit empty selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.11.1
+Version: 4.11.2
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # xcms 4.11
 
+## Changes in version 4.11.2
+
+- fix issue with `filterFeatureDefinitions(object, features)` where all
+  features would be kept (instead of removed) if the filter conditions were
+  false for exactly all features.
+
 ## Changes in version 4.11.1
 
 - `refineChromPeaks,MergeNeighboringPeakParam`: drop row names of intermediate

--- a/R/XcmsExperiment.R
+++ b/R/XcmsExperiment.R
@@ -1884,7 +1884,7 @@ setMethod(
 setMethod(
     "filterFeatureDefinitions", "XcmsExperiment",
     function(object, features = integer()) {
-        if (!length(features))
+        if (missing(features))
             return(object)
         if (!hasFeatures(object))
             stop("No feature definitions present! Please run ",

--- a/R/XcmsExperimentHdf5.R
+++ b/R/XcmsExperimentHdf5.R
@@ -1140,7 +1140,7 @@ setMethod(
 setMethod(
     "filterFeatureDefinitions", "XcmsExperimentHdf5",
     function(object, features = integer()) {
-        if (!length(features))
+        if (missing(features))
             return(object)
         if (!hasFeatures(object))
             stop("No feature definitions present! Please run ",

--- a/R/methods-XCMSnExp.R
+++ b/R/methods-XCMSnExp.R
@@ -3770,7 +3770,7 @@ setMethod(
 setMethod(
     "filterFeatureDefinitions", "XCMSnExp",
     function(object, features = integer()) {
-        if (!length(features))
+        if (missing(features))
             return(object)
         if (!hasFeatures(object))
             stop("No feature definitions present! Run 'groupChromPeaks' first.")

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1243,10 +1243,12 @@ test_that("filterFeatureDefinitions works", {
     expect_true(hasFeatures(res))
     expect_equal(featureDefinitions(res), featureDefinitions(xmseg)[1:10, ])
 
-    ## An explicit empty selection removes ALL features - it must NOT be
-    ## treated as the no-argument no-op (which would silently keep them all).
     res0 <- filterFeatureDefinitions(xmseg, integer(0))
     expect_equal(nrow(featureDefinitions(res0)), 0L)
+    
+    res0B <- filterFeatures(xmseg, RsdFilter(threshold = -1, qcIndex = 1:2))
+    expect_equal(nrow(featureDefinitions(res0B)), 0L)
+    
 })
 
 test_that("featureSpectra works", {

--- a/tests/testthat/test_XcmsExperiment.R
+++ b/tests/testthat/test_XcmsExperiment.R
@@ -1242,6 +1242,11 @@ test_that("filterFeatureDefinitions works", {
     res <- filterFeatureDefinitions(xmseg, 1:10)
     expect_true(hasFeatures(res))
     expect_equal(featureDefinitions(res), featureDefinitions(xmseg)[1:10, ])
+
+    ## An explicit empty selection removes ALL features - it must NOT be
+    ## treated as the no-argument no-op (which would silently keep them all).
+    res0 <- filterFeatureDefinitions(xmseg, integer(0))
+    expect_equal(nrow(featureDefinitions(res0)), 0L)
 })
 
 test_that("featureSpectra works", {


### PR DESCRIPTION
# Fix: `filterFeatures()` keeps ALL features (instead of none) when the filter would remove every feature

> **AI-assisted contribution.** This report and the accompanying code fix were
> prepared with the assistance of Claude Code. The reproducible example and every
> quoted output were produced by actually running the code against the `xcms`
> source; the change is covered by a regression test.

## Summary

Every `filterFeatures()` parameter class computes the indices of the features to
**keep** and hands them to `filterFeatureDefinitions()`:

```r
fts_idx <- which(vals <= filter@threshold)          # features that PASS
...
filterFeatureDefinitions(object, features = fts_idx)
```

`filterFeatureDefinitions()` starts with a no-op guard:

```r
function(object, features = integer()) {
    if (!length(features))
        return(object)          # <-- treats "empty" as "no filter" => keep everything
    ...
}
```

So when a filter is strict enough that **no** feature passes (`fts_idx` is
`integer(0)`), `filterFeatureDefinitions()` returns the object **unchanged** —
i.e. it keeps **all** features instead of removing them. The user gets a
message claiming the features were removed, so the result silently contradicts
both the intent and the reported outcome.

This affects all three implementations (same guard):
`R/XcmsExperiment.R` (`XcmsExperiment`), `R/XcmsExperimentHdf5.R`
(`XcmsExperimentHdf5`), `R/methods-XCMSnExp.R` (`XCMSnExp`).

## Reproducible example

RSD is always `>= 0`, so `threshold = -1` passes **no** feature — every feature
should be removed:

```r
library(xcms)
library(MsExperiment)

x  <- loadXcmsData("xmse")                 # 351 features
qc <- which(sampleData(x)$sample_type == "QC")

r <- filterFeatures(x, RsdFilter(threshold = -1, qcIndex = qc))
#> 351 features were removed                <-- message says all removed
nrow(featureDefinitions(r))
#> [1] 351                                  <-- but ALL 351 are still there!
```

The filter works correctly whenever at least one feature passes; only the
"remove everything" case is wrong. The same applies to any direct call
`filterFeatureDefinitions(object, features = which(<condition matching nothing>))`.
With this fix the call above returns `0` features.

## Corroborating inconsistency

The sibling `filterChromPeaks()` handles the same "remove everything" case
**correctly**: it routes through `.filterChromPeaks()`, which does
`if (!length(idx)) return(new("MsFeatureData"))` — an explicit empty selection
empties the peak table. Likewise the **`SummarizedExperiment`** `filterFeatures`
methods subset with `object[fts_idx]`, so they handle the empty case correctly.
The identical call therefore gives **inconsistent results by object type**:

```r
filterFeatures(<SummarizedExperiment>, RsdFilter(threshold = -1, ...))  # -> 0 features (correct)
filterFeatures(<XcmsExperiment>,       RsdFilter(threshold = -1, ...))  # -> 351 features (BUG)
```

The fix distinguishes "no `features` argument given" (a genuine no-op) from "an
explicit empty selection" (keep none) via `missing(features)`; the no-argument
no-op is preserved.
