### PR TITLE
fix(refineChromPeaks): avoid into=Inf when merged peak spans <=1 scan

### DIFF
--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -287,7 +287,7 @@
                 rtmin <- pks_new[current_peak, "rtmin"]
                 rtmax <- max(pks[i, "rtmax"], pks_new[current_peak, "rtmax"])
                 idx <- which(rt >= rtmin & rt <= rtmax)
-                peak_width <- (rtmax - rtmin) / (idx[length(idx)] - idx[1L])
+                peak_width <- (rtmax - rtmin) / max(1L, idx[length(idx)] - idx[1L])
                 pkm <- do.call(rbind, x[idx])
                 pks_new[current_peak, c("rtmax", "mzmin", "mzmax", "into")] <-
                     c(rtmax, range(pkm[, "mz"], na.rm = TRUE),

--- a/R/functions-Chromatogram.R
+++ b/R/functions-Chromatogram.R
@@ -127,7 +127,8 @@
                 idx_max <- which.min(
                     abs(rtime(x) - pks_new[current_peak, "rtmax"]))
                 peak_width <- (pks_new[current_peak, "rtmax"] -
-                               pks_new[current_peak, "rtmin"]) / (idx_max - idx_min)
+                               pks_new[current_peak, "rtmin"]) /
+                    max(1L, idx_max - idx_min)
                 ## Calculate into as done in centWave.
                 pks_new[current_peak, "into"] <-
                     sum(intensity(x)[rtime(x) >= pks_new[current_peak, "rtmin"] &

--- a/tests/testthat/test_functions-Chromatogram.R
+++ b/tests/testthat/test_functions-Chromatogram.R
@@ -64,3 +64,16 @@ test_that(".chrom_merge_neighboring_peaks works", {
     expect_equal(unname(res$chromPeaks[1, "into"]),
                  unname(chromPeaks(xchr)[2, "into"]))
 })
+
+test_that("merging peaks spanning a single scan does not give Inf into", {
+    chr <- XChromatogram(rtime = c(10, 20, 30), intensity = c(100, 900, 100))
+    reqn <- c("mz","mzmin","mzmax","rt","rtmin","rtmax","into","maxo","sn","sample")
+    pks  <- matrix(0, nrow = 2, ncol = length(reqn), dimnames = list(NULL, reqn))
+    pks[1, ] <- c(100,100,100, 20, 18, 21, 900, 900, 10, 1)
+    pks[2, ] <- c(100,100,100, 21, 20, 22, 500, 500, 10, 1)
+    chromPeaks(chr) <- pks
+    xchr <- XChromatograms(list(chr), nrow = 1, ncol = 1)
+    ref <- refineChromPeaks(xchr, MergeNeighboringPeaksParam(expandRt = 4,
+                                                             minProp = 0.01))
+    expect_true(all(is.finite(chromPeaks(ref)[, "into"])))
+})


### PR DESCRIPTION
# Fix: merging neighboring chromatographic peaks yields `into = Inf` when the merged peak spans ≤ 1 scan

> **AI-assisted contribution.** This report and the accompanying code fix were
> prepared with the assistance of Claude Code. The reproducible example and every
> quoted output were produced by actually running the code against the `xcms`
> source; the change is covered by a regression test.

## Summary

`refineChromPeaks(..., MergeNeighboringPeaksParam(...))` re-integrates a merged
peak as `sum(intensities) * peak_width`, where

```r
peak_width <- (rtmax - rtmin) / (idx_max - idx_min)
```

`idx_min`/`idx_max` are the indices of the retention times closest to the
merged peak's `rtmin`/`rtmax`. When the merged peak's retention-time window
covers only a **single** data point (`idx_max == idx_min`), this divides by
zero, so `peak_width` becomes `Inf` and the peak's `"into"` becomes **`Inf`**.
That `Inf` then silently propagates into `featureValues()`.

The same defect exists in both merge implementations:

- `R/functions-Chromatogram.R`, `.chrom_merge_neighboring_peaks()` (used for
  `XChromatogram` / `XChromatograms`): `… / (idx_max - idx_min)`.
- `R/XcmsExperiment-functions.R`, `.merge_neighboring_peak_candidates()` (used
  for `XcmsExperiment`): `peak_width <- (rtmax - rtmin) / (idx[length(idx)] - idx[1L])`.

This is triggered by sparse / coarse-in-rt chromatographic data (e.g.
flow-injection / direct-infusion data, fast low-scan-rate acquisitions, sparse
EICs after m/z filtering, or manually defined narrow peaks), where a merged
peak can span fewer than two scans.

## Related GitHub issue

- **Related to #825** ("refineChromPeaks,MergeNeighboringPeaksParam fails to
  merge nested peaks", open). That issue is a **different defect in the same
  function** (`.merge_neighboring_peak_candidates()`): its `order(pks[, "rtmin"])`
  sort leaves fully-nested peaks in input order so the smaller nested peak is not
  merged away. It is *not* the divide-by-zero fixed here.

## Reproducible example

```r
library(xcms)
library(MSnbase)

## A chromatogram with a COARSE rt grid (3 scans, 10 s apart) and two peaks
## whose merged rt window [18, 22] contains only ONE scan (rt = 20):
chr <- XChromatogram(rtime = c(10, 20, 30), intensity = c(100, 900, 100))
reqn <- c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "into", "maxo", "sn", "sample")
pks  <- matrix(0, nrow = 2, ncol = length(reqn), dimnames = list(NULL, reqn))
pks[1, ] <- c(100, 100, 100, 20, 18, 21, 900, 900, 10, 1)
pks[2, ] <- c(100, 100, 100, 21, 20, 22, 500, 500, 10, 1)
chromPeaks(chr) <- pks
xchr <- XChromatograms(list(chr), nrow = 1, ncol = 1)

chromPeaks(xchr)[, "into"]
#> [1] 900 500

ref <- refineChromPeaks(xchr, MergeNeighboringPeaksParam(expandRt = 4, minProp = 0.01))
chromPeaks(ref)[, "into"]
#> CPM1
#>  Inf          <-- corrupt
```

With this fix the merged peak has a finite `into` of `3600`
(`sum(intensity in [18, 22]) = 900`, `peak_width = (22 - 18) / 1 = 4`).
