### PR TITLE
fix(fillChromPeaks): centWave gap-fill integrates over the actual scan span, not the requested window

### DIFF
--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -557,7 +557,8 @@
                 res[i, c("rt", "mz", "maxo", "into")] <- c(
                     rts[maxi], mmz, mat[maxi, 2L],
                     sum(mat[, 2L], na.rm = TRUE) *
-                    (diff(range(rt[keep])) / max(1L, (length(keep) - 1L)))
+                    ((rt[keep[length(keep)]] - rt[keep[1L]]) /
+                     max(1L, (length(keep) - 1L)))
                 )
                 if ("beta_cor" %in% cn) {
                     res[i, c("beta_cor", "beta_snr")] <- .get_beta_values(

--- a/R/XcmsExperiment-functions.R
+++ b/R/XcmsExperiment-functions.R
@@ -557,7 +557,7 @@
                 res[i, c("rt", "mz", "maxo", "into")] <- c(
                     rts[maxi], mmz, mat[maxi, 2L],
                     sum(mat[, 2L], na.rm = TRUE) *
-                    ((rtr[2L] - rtr[1L]) / max(1L, (length(keep) - 1L)))
+                    (diff(range(rt[keep])) / max(1L, (length(keep) - 1L)))
                 )
                 if ("beta_cor" %in% cn) {
                     res[i, c("beta_cor", "beta_snr")] <- .get_beta_values(

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -293,7 +293,7 @@ dropGenericProcessHistory <- function(x, fun) {
                 ## window overhangs the sample's local scan coverage. Numerator
                 ## and denominator use the same scan set (all scans in the
                 ## window); max(1, ...) guards the single-scan case.
-                sel <- which(rtim >= rtr[1] & rtim <= rtr[2])
+                sel <- which(between(rtim, rtr))
                 res[i, "into"] <- sum(mtx[, 3L], na.rm = TRUE) *
                     ((rtim[sel[length(sel)]] - rtim[sel[1L]]) /
                      max(1, (length(sel) - 1)))

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -285,15 +285,18 @@ dropGenericProcessHistory <- function(x, fun) {
             if (any(!is.na(mtx[, 3]))) {
                 ## Area = sum(intensities) * rt_width, where rt_width is the mean
                 ## scan spacing = (actual rt span of the scans in the window) /
-                ## (number of those scans - 1). Using the *actual* data span
-                ## (rather than the requested window rtr[2] - rtr[1]) keeps the
-                ## filled 'into' consistent with centWave detection, which
-                ## derives pwid from the peak's actual scan times, and avoids
-                ## inflating 'into' when the feature window overhangs the
-                ## sample's local scan coverage. max(1, ...) guards single-scan.
-                rt_in <- rtim[rtim >= rtr[1] & rtim <= rtr[2]]
+                ## (number of those scans - 1). Using the actual span of the
+                ## scans in the window (rather than the requested window
+                ## rtr[2] - rtr[1]) keeps the filled 'into' consistent with
+                ## centWave detection, which derives pwid from the peak's actual
+                ## scan times, and avoids inflating 'into' when the feature
+                ## window overhangs the sample's local scan coverage. Numerator
+                ## and denominator use the same scan set (all scans in the
+                ## window); max(1, ...) guards the single-scan case.
+                sel <- which(rtim >= rtr[1] & rtim <= rtr[2])
                 res[i, "into"] <- sum(mtx[, 3L], na.rm = TRUE) *
-                    (diff(range(rt_in)) / max(1, (length(rt_in) - 1)))
+                    ((rtim[sel[length(sel)]] - rtim[sel[1L]]) /
+                     max(1, (length(sel) - 1)))
                 maxi <- which.max(mtx[, 3L])
                 res[i, c("rt", "maxo")] <- mtx[maxi[1], c(1, 3)]
                 res[i, c("rtmin", "rtmax")] <- rtr

--- a/R/functions-XCMSnExp.R
+++ b/R/functions-XCMSnExp.R
@@ -283,19 +283,17 @@ dropGenericProcessHistory <- function(x, fun) {
         if (length(mtx)) {
             ## mtx: time, mz, intensity
             if (any(!is.na(mtx[, 3]))) {
-                ## How to calculate the area: (1)sum of all intensities / (2)by
-                ## the number of data points (REAL ones, considering also NAs)
-                ## and multiplied with the (3)rt width.
-                ## (1) sum(mtx[, 3], na.rm = TRUE)
-                ## (2) sum(rtim >= rtr[1] & rtim <= rtr[2]) - 1 ; if we used
-                ## nrow(mtx) here, which would correspond to the non-NA
-                ## intensities within the rt range we don't get the same results
-                ## as e.g. centWave. Using max(1, ... to avoid getting Inf in
-                ## case the signal is based on a single data point.
-                ## (3) rtr[2] - rtr[1]
+                ## Area = sum(intensities) * rt_width, where rt_width is the mean
+                ## scan spacing = (actual rt span of the scans in the window) /
+                ## (number of those scans - 1). Using the *actual* data span
+                ## (rather than the requested window rtr[2] - rtr[1]) keeps the
+                ## filled 'into' consistent with centWave detection, which
+                ## derives pwid from the peak's actual scan times, and avoids
+                ## inflating 'into' when the feature window overhangs the
+                ## sample's local scan coverage. max(1, ...) guards single-scan.
+                rt_in <- rtim[rtim >= rtr[1] & rtim <= rtr[2]]
                 res[i, "into"] <- sum(mtx[, 3L], na.rm = TRUE) *
-                    ((rtr[2] - rtr[1]) /
-                     max(1, (sum(rtim >= rtr[1] & rtim <= rtr[2]) - 1)))
+                    (diff(range(rt_in)) / max(1, (length(rt_in) - 1)))
                 maxi <- which.max(mtx[, 3L])
                 res[i, c("rt", "maxo")] <- mtx[maxi[1], c(1, 3)]
                 res[i, c("rtmin", "rtmax")] <- rtr

--- a/tests/testthat/test_XcmsExperiment-functions.R
+++ b/tests/testthat/test_XcmsExperiment-functions.R
@@ -314,3 +314,20 @@ test_that(".xmse_combine works", {
 
     expect_error(.xmse_combine(list(a, 3)), "objects accepted")
 })
+
+test_that(".chrom_peak_intensity_centWave into is invariant to window padding", {
+    mkpm <- function(mz, i) cbind(mz = mz, intensity = i)
+    rt <- c(10, 20, 30, 40)
+    x  <- list(mkpm(c(100, 100.1), c(50, 60)), mkpm(c(100, 100.1), c(900, 800)),
+               mkpm(c(100, 100.1), c(40, 30)), mkpm(c(100, 100.1), c(10, 5)))
+    cn <- c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "into", "maxo",
+            "sn", "sample")
+    pa <- function(rtmin, rtmax) matrix(
+        c(100, 99.9, 100.2, (rtmin + rtmax) / 2, rtmin, rtmax), nrow = 1,
+        dimnames = list("F", c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax")))
+    into <- function(peakArea) xcms:::.chrom_peak_intensity_centWave(
+        x, rt, peakArea, cn = cn, sampleIndex = 1L)[, "into"]
+    ## The same 4 scans are selected by both windows; a wider *requested*
+    ## window must NOT inflate `into` (rt_width uses the actual scan span).
+    expect_equal(unname(into(pa(10, 40))), unname(into(pa(5, 45))))
+})

--- a/tests/testthat/test_methods-XCMSnExp.R
+++ b/tests/testthat/test_methods-XCMSnExp.R
@@ -1916,7 +1916,7 @@ test_that("fillChromPeaks,XCMSnExp works", {
         chr <- chromatogram(tmp, rt = cfp[1, c("rtmin", "rtmax")],
                             mz = cfp[1, c("mzmin", "mzmax")])[1, 1]
         into <- sum(intensity(chr), na.rm = TRUE) *
-            (cfp[1, "rtmax"] - cfp[1, "rtmin"]) / (length(chr) - 1)
+            diff(range(rtime(chr))) / max(1, (length(chr) - 1))
         expect_equal(unname(into), unname(cfp[1, "into"]))
     }
 
@@ -2034,9 +2034,9 @@ test_that("fillChromPeaks,XCMSnExp works", {
                        valsPerSpect = vps,
                        rtrange = fp[i, c("rtmin", "rtmax")],
                        mzrange = fp[i, c("mzmin", "mzmax")])
+        rt_in <- rtim[rtim >= fp[i, "rtmin"] & rtim <= fp[i, "rtmax"]]
         into <- sum(mtx[, 3], na.rm = TRUE) *
-            ((fp[i, "rtmax"] - fp[i, "rtmin"]) /
-             (sum(rtim >= fp[i, "rtmin"] & rtim <= fp[i, "rtmax"]) - 1))
+            (diff(range(rt_in)) / max(1, (length(rt_in) - 1)))
         expect_equal(unname(into), unname(fp[i, "into"]))
     }
     ## Drop them.


### PR DESCRIPTION
# Fix: centWave gap-filling integrates over the requested window instead of the actual scan span (inflates `into`)

> **AI-assisted contribution.** This report and the accompanying code fix were
> prepared with the assistance of Claude Code. The reproducible example and every
> quoted output were produced by actually running the code against the `xcms`
> source; the change is covered by a regression test.

## Summary

The centWave gap-fill integrators compute the filled peak's `"into"` as
`sum(intensities) × rt_width`, where `rt_width` is meant to be the mean per-scan
time step Δt in the Riemann sum `∫ I dt ≈ Δt · Σ I`. They compute Δt from the
**requested feature window**:

```r
rt_width <- (rtmax - rtmin) / (n_scans - 1)       # rtmax/rtmin = feature window
```

During gap filling the window `(rtmin, rtmax)` is the **cross-sample consensus**
feature window, which can be wider than the sample's actual scan coverage in
that window. `rt_width` is then larger than the true mean scan spacing, so
`into` is inflated by `requested_width / actual_span` and depends on how the
feature window happens to be padded.

This is inconsistent with two references that both use the **actual scan span**:

- **centWave detection** derives `into` from the peak's real scan times
  (`R/do_findChromPeaks-functions.R`):
  `pwid <- (scantime[hi] - scantime[lo]) / (hi - lo); into <- pwid * sum(pd)`,
  where `hi`/`lo` are the peak's actual boundary scans.
- The **matchedFilter gap-fill** already uses
  `diff(rt[idx_rt_range]) / diff(idx_rt_range)` — the actual data span.

Two centWave gap-fill functions are affected:

- `R/XcmsExperiment-functions.R`, `.chrom_peak_intensity_centWave()`
  (used by `fillChromPeaks()` on `XcmsExperiment`).
- `R/functions-XCMSnExp.R`, `.getChromPeakData()`
  (used by `fillChromPeaks()` on `XCMSnExp`).

The fix uses the actual rt span of the scans in the window, so gap-filled `into`
matches centWave detection and no longer depends on window padding. Values for
windows that already match the data span (the common case) are unchanged.

## Reproducible example

Integrating the **same four scans** with a tight window (`[10, 40]`, equal to
the data span) vs. a padded window (`[5, 45]`, 5 s wider on each side):

```r
library(xcms)

mkpm <- function(mz, i) cbind(mz = mz, intensity = i)
rt <- c(10, 20, 30, 40)
x  <- list(mkpm(c(100, 100.1), c(50, 60)), mkpm(c(100, 100.1), c(900, 800)),
           mkpm(c(100, 100.1), c(40, 30)), mkpm(c(100, 100.1), c(10, 5)))
cn <- c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax", "into", "maxo", "sn", "sample")
pa <- function(rtmin, rtmax) matrix(
    c(100, 99.9, 100.2, (rtmin + rtmax) / 2, rtmin, rtmax), nrow = 1,
    dimnames = list("F", c("mz", "mzmin", "mzmax", "rt", "rtmin", "rtmax")))
into <- function(peakArea) xcms:::.chrom_peak_intensity_centWave(
    x, rt, peakArea, cn = cn, sampleIndex = 1L)[, "into"]

into(pa(10, 40))     # window == data span
into(pa(5, 45))      # same scans, wider window
```

Current source (before the fix):

```
tight [10,40] into = 18950
padded[5,45]  into = 25267      # 1.333x larger for the SAME signal (= 40/30)
```

With this fix both return `18950` — `into` no longer depends on the requested
window width, only on the signal actually present.

