### PR TITLE
fix: workaround for error reading character subsets from HDF5

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -161,7 +161,7 @@ jobs:
           ## Ideally, all dependencies should get installed in the first pass.
           install.packages(c("remotes", "devtools"))
           BiocManager::install("RforMassSpectrometry/Chromatograms")
-          devtools::install_deps()
+          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories())
         continue-on-error: true
         shell: Rscript {0}
 
@@ -169,7 +169,7 @@ jobs:
         run: |
           ## Pass #2 at installing dependencies
           ## For running the checks
-          devtools::install_deps()
+          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories())
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
           BiocManager::install(c("rcmdcheck", "BiocCheck"))
         shell: Rscript {0}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -159,9 +159,12 @@ jobs:
           ## https://stat.ethz.ch/pipermail/bioc-devel/2020-April/016675.html
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
-          install.packages(c("remotes", "devtools"))
-          BiocManager::install("RforMassSpectrometry/Chromatograms")
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories())
+          install.packages(c("remotes", "devtools", "pak"))
+          library(pak)
+          repo_add(.list = BiocManager::repositories())
+          local_install_dev_deps()
+          local_install_deps()
+          local_install()
         continue-on-error: true
         shell: Rscript {0}
 
@@ -169,7 +172,11 @@ jobs:
         run: |
           ## Pass #2 at installing dependencies
           ## For running the checks
-          remotes::install_local(dependencies = TRUE, repos = BiocManager::repositories())
+          library(pak)
+          repo_add(.list = BiocManager::repositories())
+          local_install_dev_deps()
+          local_install_deps()
+          local_install()
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
           BiocManager::install(c("rcmdcheck", "BiocCheck"))
         shell: Rscript {0}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -124,7 +124,9 @@ jobs:
       - name: Install macOS system dependencies
         if: matrix.config.os == 'macOS-latest'
         run: |
-          brew install gettext
+          source("https://mac.R-project.org/bin/install.R")
+          install.libs("gettext")
+        shell: Rscript {0}
 
       - name: Install Windows system dependencies
         if: runner.os == 'Windows'

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -163,7 +163,6 @@ jobs:
           BiocManager::install("RforMassSpectrometry/Chromatograms")
           install.packages("pak")
           pak::local_install_dev_deps(ask = FALSE)
-          pak::local_install(depdendencies = TRUE)
         continue-on-error: true
         shell: Rscript {0}
 
@@ -171,6 +170,7 @@ jobs:
         run: |
           ## Pass #2 at installing dependencies
           ## For running the checks
+          pak::local_install(dependencies = TRUE)
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
           BiocManager::install(c("rcmdcheck", "BiocCheck"))
         shell: Rscript {0}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -159,10 +159,9 @@ jobs:
           ## https://stat.ethz.ch/pipermail/bioc-devel/2020-April/016675.html
           ## https://github.com/r-lib/remotes/issues/296
           ## Ideally, all dependencies should get installed in the first pass.
-          install.packages("remotes")
+          install.packages(c("remotes", "devtools"))
           BiocManager::install("RforMassSpectrometry/Chromatograms")
-          install.packages("pak")
-          pak::local_install_dev_deps(ask = FALSE)
+          devtools::install_deps()
         continue-on-error: true
         shell: Rscript {0}
 
@@ -170,7 +169,7 @@ jobs:
         run: |
           ## Pass #2 at installing dependencies
           ## For running the checks
-          pak::local_install(dependencies = TRUE)
+          devtools::install_deps()
           message(paste('****', Sys.time(), 'installing rcmdcheck and BiocCheck ****'))
           BiocManager::install(c("rcmdcheck", "BiocCheck"))
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: xcms
-Version: 4.11.2
+Version: 4.11.3
 Title: LC-MS and GC-MS Data Analysis
 Description: Framework for processing and visualization of chromatographically
     separated and single-spectra mass spectral data. Imports from AIA/ANDI NetCDF,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -390,8 +390,6 @@ exportMethods("hasChromPeaks",
               )
 
 ## feature grouping functions and methods.
-importFrom("MsCoreUtils",
-           "group")
 importMethodsFrom("MsFeatures",
                   "featureGroups",
 		  "featureGroups<-",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # xcms 4.11
 
+## Changes in version 4.11.3
+
+- Workaround for errors reading subsets of data from HDF5 files with
+  `XcmsExperimentHdf5`: original issue reported in *rhdf5*:
+  https://github.com/Huber-group-EMBL/rhdf5/issues/240 . Code can be reverted
+  once the problem is fixed upstream in *rhdf5*.
+
 ## Changes in version 4.11.2
 
 - Add support to return chromatographic data as a `Chromatograms` object with

--- a/R/XcmsExperimentHdf5-functions.R
+++ b/R/XcmsExperimentHdf5-functions.R
@@ -1315,12 +1315,20 @@ XcmsExperimentHdf5 <- function() {
                             read_rownames = FALSE,
                             rownames = paste0(name, "_rownames")) {
     d <- rhdf5::h5read(h5, name = name, index = index)
-    if (read_rownames)
-        rownames(d) <- rhdf5::h5read(h5, name = rownames, drop = TRUE,
-                                     index = index[1L])
-    if (read_colnames)
-        colnames(d) <- rhdf5::h5read(h5, name = paste0(name, "_colnames"),
-                                     drop = TRUE, index = index[2L])
+    if (read_rownames) {
+        rn <- rhdf5::h5read(h5, name = rownames, drop = TRUE)
+        if (length(index[[1L]]))
+            rownames(d) <- rn[index[[1L]]]
+        else rownames(d) <- rn
+    }
+    if (read_colnames) {
+        cn <- rhdf5::h5read(h5, name = paste0(name, "_colnames"), drop = TRUE)
+        if (length(index[[2L]]))
+            colnames(d) <- cn[index[[2L]]]
+        else colnames(d) <- cn
+        ## colnames(d) <- rhdf5::h5read(h5, name = paste0(name, "_colnames"),
+        ##                              drop = TRUE, index = index[2L])
+    }
     d
 }
 
@@ -1339,12 +1347,18 @@ XcmsExperimentHdf5 <- function() {
         d <- d[index[[1L]], , drop = FALSE]
     if (!is.null(index[[2L]]))
         d <- d[, index[[2L]], drop = FALSE]
-    if (read_rownames)
-        rownames(d) <- rhdf5::h5read(h5, name = rownames, drop = TRUE,
-                                     index = index[1L])
-    if (read_colnames)
-        colnames(d) <- rhdf5::h5read(h5, name = paste0(name, "_colnames"),
-                                     drop = TRUE, index = index[2L])
+    if (read_rownames) {
+        rn <- rhdf5::h5read(h5, name = rownames, drop = TRUE)
+        if (length(index[[1L]]))
+            rownames(d) <- rn[index[[1L]]]
+        else rownames(d) <- rn
+    }
+    if (read_colnames) {
+        cn <- rhdf5::h5read(h5, name = paste0(name, "_colnames"), drop = TRUE)
+        if (length(index[[2L]]))
+            colnames(d) <- cn[index[[2L]]]
+        else colnames(d) <- cn
+    }
     d
 }
 
@@ -1360,7 +1374,7 @@ XcmsExperimentHdf5 <- function() {
         name, h5, index, read_colnames, read_rownames, rownames)
     if (length(rt) | length(mz))
         d <- d[.is_chrom_peak_within_mz_rt(d, rt = rt, mz = mz,
-                                            ppm = ppm, type = type), ,
+                                           ppm = ppm, type = type), ,
                drop = FALSE]
     ## If sample_index is provided add a column "sample" with the index.
     if (length(sample_index))
@@ -1629,8 +1643,7 @@ XcmsExperimentHdf5 <- function() {
 #' @noRd
 .h5_increment_mod_count <- function(h5) {
     mc <- .h5_mod_count(h5) + 1L
-    rhdf5::h5write(mc, h5, "/header/modcount",
-                   level = .h5_compression_level())
+    rhdf5::h5write(mc, h5, "/header/modcount")
     mc
 }
 


### PR DESCRIPTION
- Reading subsets of a character array defined by indices from an HDF5 file causes errors. The bug is reported for *rhdf5* in issue https://github.com/Huber-group-EMBL/rhdf5/issues/240 . This commit adds a workaround that reads the full character vector and subsets it by index in R.